### PR TITLE
Add splines decoding and rendering

### DIFF
--- a/crates/jxl-frame/src/data/lf_global.rs
+++ b/crates/jxl-frame/src/data/lf_global.rs
@@ -38,7 +38,7 @@ impl Bundle<(&Headers, &FrameHeader)> for LfGlobal {
             Patches::parse(bitstream, image_header)
         }).transpose()?;
         let splines = header.flags.splines().then(|| {
-            Splines::parse(bitstream, ())
+            Splines::parse(bitstream, header)
         }).transpose()?;
         let noise = header.flags.noise().then(|| {
             NoiseParameters::parse(bitstream, ())

--- a/crates/jxl-frame/src/data/mod.rs
+++ b/crates/jxl-frame/src/data/mod.rs
@@ -15,4 +15,4 @@ mod patch;
 mod spline;
 pub use noise::NoiseParameters;
 pub use patch::*;
-pub use spline::Splines;
+pub use spline::{Splines, Spline};

--- a/crates/jxl-frame/src/data/mod.rs
+++ b/crates/jxl-frame/src/data/mod.rs
@@ -15,4 +15,4 @@ mod patch;
 mod spline;
 pub use noise::NoiseParameters;
 pub use patch::*;
-pub use spline::{Splines, Spline};
+pub use spline::{Splines, Spline, continuous_idct, erf};

--- a/crates/jxl-frame/src/data/spline.rs
+++ b/crates/jxl-frame/src/data/spline.rs
@@ -1,15 +1,24 @@
-#![allow(unused_variables, unused_mut, dead_code)]
+#![allow(unused_variables, unused_mut, dead_code, clippy::needless_range_loop)]
 
 use std::io::Read;
 
-use jxl_bitstream::{Bitstream, Bundle};
+use jxl_bitstream::{unpack_signed, Bitstream, Bundle};
+use jxl_coding::Decoder;
 
 use crate::Result;
 
 #[derive(Debug)]
 pub struct Splines {
-    coords: Vec<(i32, i32)>,
+    pub splines: Vec<QuantSpline>,
+    start_points: Vec<(i32, i32)>,
     quant_adjust: i32,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct QuantSpline {
+    points_deltas: Vec<(i32, i32)>,
+    xyb_dct: [[i32; 32]; 3],
+    sigma_dct: [i32; 32],
 }
 
 impl<Ctx> Bundle<Ctx> for Splines {
@@ -19,8 +28,64 @@ impl<Ctx> Bundle<Ctx> for Splines {
         let mut decoder = jxl_coding::Decoder::parse(bitstream, 6)?;
         decoder.begin(bitstream)?;
 
-        let num_splines = decoder.read_varint(bitstream, 2)? + 1;
-        let mut last = (0i32, 0i32);
-        todo!()
+        let num_splines = (decoder.read_varint(bitstream, 2)? + 1) as usize;
+        
+        let mut start_points = vec![(0i32, 0i32); num_splines];
+        for i in 0..num_splines {
+            let mut x = decoder.read_varint(bitstream, 1)? as i32;
+            let mut y = decoder.read_varint(bitstream, 1)? as i32;
+            if i != 0 {
+                x = unpack_signed(x as u32) + start_points[i - 1].0;
+                y = unpack_signed(y as u32) + start_points[i - 1].1;
+            }
+            start_points[i].0 = x;
+            start_points[i].1 = y;
+        }
+
+        let quant_adjust = unpack_signed(decoder.read_varint(bitstream, 0)?);
+
+        let mut splines = vec![QuantSpline::new(); num_splines];
+        for spline in &mut splines {
+            spline.decode(&mut decoder, bitstream)?;
+        }
+
+        Ok(Self {
+            quant_adjust,
+            splines,
+            start_points,
+        })
     }
 }
+
+impl QuantSpline {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn decode<R: Read>(
+        &mut self,
+        decoder: &mut Decoder,
+        bitstream: &mut Bitstream<R>,
+    ) -> Result<()> {
+        let num_points = decoder.read_varint(bitstream, 3)? as usize;
+        self.points_deltas.resize(num_points, (0, 0));
+
+        for cp in &mut self.points_deltas {
+            cp.0 = unpack_signed(decoder.read_varint(bitstream, 4)?);
+            cp.1 = unpack_signed(decoder.read_varint(bitstream, 4)?);
+        }
+        for color_dct in &mut self.xyb_dct {
+            for i in color_dct {
+                *i = unpack_signed(decoder.read_varint(bitstream, 5)?);
+            }
+        }
+        for i in &mut self.sigma_dct {
+            *i = unpack_signed(decoder.read_varint(bitstream, 5)?);
+        }
+        Ok(())
+    }
+
+}
+
+}
+

--- a/crates/jxl-frame/src/data/spline.rs
+++ b/crates/jxl-frame/src/data/spline.rs
@@ -120,7 +120,6 @@ impl QuantSpline {
         Ok(())
     }
 
-    // TODO check Maximum total_estimated_area_reached
     pub fn dequant(
         &self,
         quant_adjust: i32,

--- a/crates/jxl-frame/src/data/spline.rs
+++ b/crates/jxl-frame/src/data/spline.rs
@@ -14,6 +14,13 @@ pub struct Splines {
     quant_adjust: i32,
 }
 
+#[derive(Debug, Default)]
+pub struct Spline {
+    points: Vec<(f32, f32)>,
+    xyb_dct: [[f32; 32]; 3],
+    sigma_dct: [f32; 32],
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct QuantSpline {
     points_deltas: Vec<(i32, i32)>,
@@ -29,7 +36,7 @@ impl<Ctx> Bundle<Ctx> for Splines {
         decoder.begin(bitstream)?;
 
         let num_splines = (decoder.read_varint(bitstream, 2)? + 1) as usize;
-        
+
         let mut start_points = vec![(0i32, 0i32); num_splines];
         for i in 0..num_splines {
             let mut x = decoder.read_varint(bitstream, 1)? as i32;
@@ -85,7 +92,63 @@ impl QuantSpline {
         Ok(())
     }
 
-}
+    fn dequant(
+        &self,
+        start_point: (i32, i32),
+        quant_adjust: i32,
+        base_correlation_x: f32,
+        base_correlation_b: f32,
+    ) -> Spline {
+        let mut manhattan_distance = 0;
+        let mut points = Vec::with_capacity(self.points_deltas.len() + 1);
 
+        let mut cur_value = start_point;
+        points.push((cur_value.0 as f32, cur_value.1 as f32));
+        let mut cur_delta = (0, 0);
+        for delta in &self.points_deltas {
+            cur_delta.0 += delta.0;
+            cur_delta.1 += delta.1;
+            manhattan_distance += cur_delta.0.abs() + cur_delta.1.abs();
+            cur_value.0 += cur_delta.0;
+            cur_value.1 += cur_delta.1;
+            points.push((cur_value.0 as f32, cur_value.1 as f32));
+        }
+
+        let mut xyb_dct = [[0f32; 32]; 3];
+        let mut sigma_dct = [0f32; 32];
+        let mut width_estimate = 0f32;
+
+        let quant_adjust = quant_adjust as f32;
+        let inverted_qa = if quant_adjust >= 0.0 {
+            1.0 / (1.0 + quant_adjust / 8.0)
+        } else {
+            1.0 - quant_adjust / 8.0
+        };
+
+        const CHANNEL_WEIGHTS: [f32; 4] = [0.0042, 0.075, 0.07, 0.3333];
+        for chan_idx in 0..2 {
+            for i in 0..32 {
+                xyb_dct[chan_idx][i] =
+                    self.xyb_dct[chan_idx][i] as f32 * CHANNEL_WEIGHTS[chan_idx] * inverted_qa;
+            }
+        }
+        for i in 0..32 {
+            xyb_dct[0][i] += base_correlation_x * xyb_dct[1][i];
+            xyb_dct[2][i] += base_correlation_b * xyb_dct[1][i];
+        }
+        for i in 0..32 {
+            sigma_dct[i] = self.sigma_dct[i] as f32 * CHANNEL_WEIGHTS[3] * inverted_qa;
+            let weight = (self.sigma_dct[i]).abs() as f32 * (inverted_qa).ceil();
+            width_estimate += weight * weight;
+        }
+
+        let estimated_area_reached = width_estimate * manhattan_distance as f32;
+
+        Spline {
+            points,
+            xyb_dct,
+            sigma_dct,
+        }
+    }
 }
 

--- a/crates/jxl-frame/src/data/spline.rs
+++ b/crates/jxl-frame/src/data/spline.rs
@@ -1,6 +1,6 @@
 #![allow(unused_variables, unused_mut, dead_code, clippy::needless_range_loop)]
 
-use std::io::Read;
+use std::{fmt::Write, io::Read};
 
 use jxl_bitstream::{unpack_signed, Bitstream, Bundle};
 use jxl_coding::Decoder;
@@ -54,6 +54,12 @@ impl<Ctx> Bundle<Ctx> for Splines {
         let mut splines = vec![QuantSpline::new(); num_splines];
         for spline in &mut splines {
             spline.decode(&mut decoder, bitstream)?;
+        }
+
+        // TODO remove this 
+        for (i, spline) in splines.iter().enumerate() {
+            let a = spline.dequant(start_points[i], quant_adjust, 0.0, 0.0);
+            tracing::debug!("\n{}", a.to_string());
         }
 
         Ok(Self {
@@ -152,3 +158,19 @@ impl QuantSpline {
     }
 }
 
+impl ToString for Spline {
+    fn to_string(&self) -> String {
+        let mut res = String::from("Spline\n");
+        for i in self.xyb_dct.iter().chain(&[self.sigma_dct]) {
+            for val in i {
+                write!(res, "{} ", val).unwrap();
+            }
+            writeln!(res).unwrap();
+        }
+        for point in &self.points {
+            writeln!(res, "{} {}", point.0 as i32, point.1 as i32).unwrap();
+        }
+        writeln!(res, "EndSpline").unwrap();
+        res
+    }
+}

--- a/crates/jxl-frame/src/error.rs
+++ b/crates/jxl-frame/src/error.rs
@@ -8,6 +8,9 @@ pub enum Error {
     IncompleteFrameData {
         field: &'static str,
     },
+    TooManySplines(usize),
+    TooManySplinePoints(usize),
+    TooLargeEstimatedArea(u64),
 }
 
 impl From<jxl_bitstream::Error> for Error {
@@ -43,6 +46,9 @@ impl std::fmt::Display for Error {
             Self::VarDct(err) => write!(f, "vardct error: {}", err),
             Self::InvalidTocPermutation => write!(f, "invalid TOC permutation"),
             Self::IncompleteFrameData { field } => write!(f, "incomplete frame data: {} is missing", field),
+            Self::TooManySplines(num) => write!(f, "Too many splines: {}", num),
+            Self::TooManySplinePoints(num) => write!(f, "Too many spline control points: {}", num),
+            Self::TooLargeEstimatedArea(area) => write!(f, "Too large estimated area for splines: {}", area),
         }
     }
 }

--- a/crates/jxl-render/src/blend.rs
+++ b/crates/jxl-render/src/blend.rs
@@ -1,5 +1,5 @@
 use jxl_frame::{
-    data::{continuous_idct, erf, BlendingModeInformation, PatchRef, Spline},
+    data::{BlendingModeInformation, PatchRef, continuous_idct, Spline, erf},
     header::BlendingInfo,
     Frame,
 };
@@ -337,75 +337,59 @@ pub fn patch(
     }
 }
 
-#[allow(unused_variables, unreachable_code)]
 pub fn spline(
     image_header: &Headers,
     base_grid: &mut [SimpleGrid<f32>],
     spline: Spline,
-    estimated_area: u64,
 ) -> crate::Result<()> {
-    // Maximum total_estimated_area_reached for Level 5
-    if estimated_area
-        > (image_header.size.height * image_header.size.width + (1 << 18)).min(1 << 22) as u64
-    {
-        tracing::warn!(
-            "Large estimated_area of splines, expect slower decoding: {}",
-            estimated_area
-        );
-    }
-    // Maximum total_estimated_area_reached for Level 10
-    // if estimated_area
-    //     > (64 * (image_header.size.height * image_header.size.width) as u64 + (1u64 << 34))
-    //         .min(1u64 << 38)
-    // {
-    //     return Err(crate::Error::Frame(
-    //         jxl_frame::Error::TooLargeEstimatedArea(estimated_area),
-    //     ));
-    // }
+    tracing::trace!("{}", spline);
 
-    let all_samaples = spline.get_samples();
-    let arclength = all_samaples.len() as f32 - 2.0 + all_samaples.last().unwrap().lenght;
-    for (i, arc) in all_samaples.iter().enumerate() {
+    let all_samples = spline.get_samples();
+    let arclength = all_samples.len() as f32 - 2.0 + all_samples.last().unwrap().length;
+    for (i, arc) in all_samples.iter().enumerate() {
         let arclength_from_start = f32::min(1.0, (i as f32) / arclength);
 
         let t = 31.0 * arclength_from_start;
         let sigma = continuous_idct(&spline.sigma_dct, t);
         let inv_sigma = 1.0 / sigma;
-        let max_distance = -2.0 * 0.1f32.ln() * sigma * sigma;
+        let values = [
+            continuous_idct(&spline.xyb_dct[0], t) * arc.length,
+            continuous_idct(&spline.xyb_dct[1], t) * arc.length,
+            continuous_idct(&spline.xyb_dct[2], t) * arc.length,
+        ];
+
+        let max_color = f32::max(0.01, values.into_iter().reduce(f32::max).unwrap());
+        let max_distance = f32::sqrt(2.0 * (f32::ln(10.0) * 3.0 + max_color)) * sigma.abs();
 
         let xbegin = i32::max(0, (arc.point.x - max_distance + 0.5).floor() as i32);
         let xend = i32::min(
-            (image_header.size.width - 1) as i32,
-            (arc.point.x + max_distance + 0.5).floor() as i32,
+            (image_header.size.width) as i32,
+            (arc.point.x + max_distance + 1.5).floor() as i32,
         );
         let ybegin = i32::max(0, (arc.point.y - max_distance + 0.5).floor() as i32);
         let yend = i32::min(
-            (image_header.size.height - 1) as i32,
-            (arc.point.y + max_distance + 0.5).floor() as i32,
+            (image_header.size.height) as i32,
+            (arc.point.y + max_distance + 1.5).floor() as i32,
         );
 
         #[allow(clippy::needless_range_loop)]
         for channel in 0..3 {
-            let value = continuous_idct(
-                &spline.xyb_dct[channel],
-                t,
-            );
             let buffer = &mut base_grid[channel];
             for y in ybegin..yend {
                 for x in xbegin..xend {
                     let sample = buffer.get_mut(x as usize, y as usize).unwrap();
-                    let dx = arc.point.x - x as f32;
-                    let dy = arc.point.y - y as f32;
+                    let dx = (x as f32) - arc.point.x;
+                    let dy = (y as f32) - arc.point.y;
                     let distance = f32::sqrt(dx * dx + dy * dy);
                     const SQRT_0125: f32 = 0.353_553_38;
                     let factor = erf((0.5 * distance + SQRT_0125) * inv_sigma)
                         - erf((0.5 * distance - SQRT_0125) * inv_sigma);
-                    *sample += 0.25 * value * sigma * factor * factor;
+                    let extra = 0.25 * values[channel] * sigma * factor * factor;
+                    *sample += extra;
                 }
             }
         }
     }
-    tracing::trace!("{}", spline);
     Ok(())
 }
 

--- a/crates/jxl-render/src/blend.rs
+++ b/crates/jxl-render/src/blend.rs
@@ -1,4 +1,4 @@
-use jxl_frame::{Frame, header::BlendingInfo, data::{PatchRef, BlendingModeInformation}};
+use jxl_frame::{Frame, header::BlendingInfo, data::{PatchRef, BlendingModeInformation, Spline}};
 use jxl_grid::SimpleGrid;
 use jxl_image::Headers;
 
@@ -331,6 +331,31 @@ pub fn patch(
             blend_single(base_grid, &patch_ref_grid[idx], &blend_params);
         }
     }
+}
+
+#[allow(unused_variables, unreachable_code)]
+pub fn spline(
+    image_header: &Headers,
+    base_grid: &mut [SimpleGrid<f32>],
+    spline: Spline,
+    estimated_area: u64
+) -> crate::Result<()> {
+    if estimated_area > (image_header.size.height * image_header.size.width + (1 << 18)).min(1 << 22) as u64 {
+        tracing::warn!(
+            "Large estimated_area of splines, expect slower decoding: {}",
+            estimated_area
+        );
+    }
+    if estimated_area
+        > (64 * (image_header.size.height * image_header.size.width) as u64 + (1u64 << 34)).min(1u64 << 38)
+    {
+        return Err(crate::Error::Frame(
+            jxl_frame::Error::TooLargeEstimatedArea(estimated_area),
+        ));
+    }
+    println!("{}", spline);
+    todo!();
+    Ok(())
 }
 
 fn blend_single(base: &mut SimpleGrid<f32>, new_grid: &SimpleGrid<f32>, blend_params: &BlendParams<'_>) {

--- a/crates/jxl-render/src/lib.rs
+++ b/crates/jxl-render/src/lib.rs
@@ -312,7 +312,22 @@ impl<'f> ContextInner<'f> {
             }
         }
 
-        if let Some(_splines) = &lf_global.splines {
+        if let Some(splines) = &lf_global.splines {
+            let mut estimated_area = 0;
+            let base_correlations_xb = lf_global.vardct.as_ref().map(|x| {
+                (
+                    x.lf_chan_corr.base_correlation_x,
+                    x.lf_chan_corr.base_correlation_b,
+                )
+            });
+            for quant_spline in &splines.quant_splines {
+                let spline = quant_spline.dequant(
+                    splines.quant_adjust,
+                    base_correlations_xb,
+                    &mut estimated_area,
+                );
+                blend::spline(self.image_header, grid, spline, estimated_area)?;
+            }
             tracing::warn!("Splines are not supported");
         }
 

--- a/crates/jxl-render/src/lib.rs
+++ b/crates/jxl-render/src/lib.rs
@@ -328,7 +328,6 @@ impl<'f> ContextInner<'f> {
                 );
                 blend::spline(self.image_header, grid, spline, estimated_area)?;
             }
-            tracing::warn!("Splines are not supported");
         }
 
         if let Some(_noise) = &lf_global.noise {

--- a/crates/jxl-render/src/lib.rs
+++ b/crates/jxl-render/src/lib.rs
@@ -326,7 +326,25 @@ impl<'f> ContextInner<'f> {
                     base_correlations_xb,
                     &mut estimated_area,
                 );
-                blend::spline(self.image_header, grid, spline, estimated_area)?;
+                // Maximum total_estimated_area_reached for Level 5
+                if estimated_area
+                    > (self.image_header.size.height * self.image_header.size.width + (1 << 18)).min(1 << 22) as u64
+                {
+                    tracing::warn!(
+                        "Large estimated_area of splines, expect slower decoding: {}",
+                        estimated_area
+                    );
+                }
+                // Maximum total_estimated_area_reached for Level 10
+                // if estimated_area
+                //     > (64 * (self.image_header.size.height * self.image_header.size.width) as u64 + (1u64 << 34))
+                //         .min(1u64 << 38)
+                // {
+                //     return Err(crate::Error::Frame(
+                //         jxl_frame::Error::TooLargeEstimatedArea(estimated_area),
+                //     ));
+                // }
+                blend::spline(self.image_header, grid, spline)?;
             }
         }
 


### PR DESCRIPTION
Spline decoding and rendering.

`Splines` are decoded as vector of `QuantSpline` -- splines with quantized DCT coefficients, and delta encoded control point coordinates.

`QuantSpline` can be decoded to `Spline` using `QuantSpline::dequant` (probably, at the rendering stage, as it requires base_correlation for X and B from `LfChannelCorrelation`)

`Spline::fmt` formatting is done in  jxl_from_tree syntax