### PR TITLE
jxl-coding: Fix ANS unused zeroing

### DIFF
--- a/crates/jxl-coding/src/ans.rs
+++ b/crates/jxl-coding/src/ans.rs
@@ -89,7 +89,6 @@ impl Histogram {
                     }
                     repeat_ranges.push(idx..(idx + repeat_count));
                     idx += repeat_count;
-                    dist[idx] = 0;
                     continue;
                 }
                 match &mut omit_data {


### PR DESCRIPTION
Fixes
```sh
Thread 'main' panicked at 'index out of bounds: the len is 32 but the index is 32',
crates/jxl-coding/src/ans.rs:92:21
```