### PR TITLE
jxl-render: Fix framebuffer size rounding for chroma subsampled images

### DIFF
--- a/crates/jxl-oxide/tests/decode.rs
+++ b/crates/jxl-oxide/tests/decode.rs
@@ -132,4 +132,5 @@ test! {
     starrail_jpegli_xyb,
     issue_24,
     issue_26,
+    issue_32,
 }

--- a/crates/jxl-render/src/cut_grid.rs
+++ b/crates/jxl-render/src/cut_grid.rs
@@ -67,7 +67,7 @@ pub fn cut_with_block_info<'g>(
                 let x = coeff.bx;
                 let y = coeff.by;
                 let sx = x >> hshift;
-                let sy = y >> hshift;
+                let sy = y >> vshift;
                 if (sx << hshift) != x || (sy << vshift) != y {
                     continue;
                 }

--- a/crates/jxl-render/src/inner.rs
+++ b/crates/jxl-render/src/inner.rs
@@ -540,8 +540,19 @@ impl<'f> ContextInner<'f> {
 
         let width = frame_header.color_sample_width() as usize;
         let height = frame_header.color_sample_height() as usize;
-        let width_rounded = ((width + 7) / 8) * 8;
-        let height_rounded = ((height + 7) / 8) * 8;
+        let (width_rounded, height_rounded) = {
+            let mut bw = (width + 7) / 8;
+            let mut bh = (height + 7) / 8;
+            let h_upsample = jpeg_upsampling.into_iter().any(|j| j == 1 || j == 2);
+            let v_upsample = jpeg_upsampling.into_iter().any(|j| j == 1 || j == 3);
+            if h_upsample {
+                bw = (bw + 1) / 2 * 2;
+            }
+            if v_upsample {
+                bh = (bh + 1) / 2 * 2;
+            }
+            (bw * 8, bh * 8)
+        };
         let mut fb_xyb = [
             SimpleGrid::new(width_rounded, height_rounded),
             SimpleGrid::new(width_rounded, height_rounded),


### PR DESCRIPTION
Fixes #32

Fixes the size of framebuffer being smaller than required.