### PR TITLE
jxl-frame: TOC entry count limit

### DIFF
--- a/crates/jxl-frame/src/data/toc.rs
+++ b/crates/jxl-frame/src/data/toc.rs
@@ -162,6 +162,12 @@ impl Bundle<&crate::FrameHeader> for Toc {
             1 + ctx.num_lf_groups() + 1 + num_groups * num_passes
         };
 
+        if entry_count > 65536 {
+            return Err(jxl_bitstream::Error::ValidationFailed(
+                "Too many TOC entries"
+            ).into());
+        }
+
         let permutated_toc = bitstream.read_bool()?;
         let permutation = if permutated_toc {
             let mut decoder = jxl_coding::Decoder::parse(bitstream, 8)?;


### PR DESCRIPTION
Prevent OOM on invalid images with enormous amount of toc_entries

https://github.com/libjxl/libjxl/blob/c2e546a17fa579748edae2667ebb04e1a9a61783/lib/jxl/toc.cc#L25-L30