### PR TITLE
Add spot colour channel rendering

### DIFF
--- a/crates/jxl-oxide/tests/conformance.rs
+++ b/crates/jxl-oxide/tests/conformance.rs
@@ -76,6 +76,7 @@ fn run_test<R: std::io::Read>(
     let debug = std::env::var("JXL_OXIDE_DEBUG").is_ok();
 
     let mut renderer = image.renderer();
+    renderer.set_render_spot_colour(false);
 
     let transform = target_icc.map(|target_icc| {
         let source_profile = Profile::new_icc(&renderer.rendered_icc()).expect("failed to parse ICC profile");


### PR DESCRIPTION
Adds rendering of spot color channels by default, a `set_render_spot_colour` method to enable/disable their rendering  and a `render_spot_colour` method to get the value of that flag in `JxlRenderer`

Rendering of spot channels onto color channels is disabled during conformance testing since they are tested as separate channels

fixes https://github.com/tirr-c/jxl-oxide/issues/15

| before: | after: |
| - | - |
|![before](https://github.com/tirr-c/jxl-oxide/assets/69643766/7bb4f3d2-14ba-45c3-8329-10bd9f065e49)| ![after](https://github.com/tirr-c/jxl-oxide/assets/69643766/ae546ae9-518e-4a8c-a7d2-fd89244c32c2)|