### PR TITLE
jxl-dec: Do not emit sRGB chunks

### DIFF
--- a/crates/jxl-oxide-cli/src/bin/jxl-dec.rs
+++ b/crates/jxl-oxide-cli/src/bin/jxl-dec.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use clap::Parser;
-use jxl_oxide::{JxlImage, CropInfo, FrameBuffer, color::RenderingIntent, PixelFormat};
+use jxl_oxide::{JxlImage, CropInfo, FrameBuffer, PixelFormat};
 use lcms2::Profile;
 
 enum LcmsTransform {
@@ -282,15 +282,6 @@ fn main() {
                 Some((icc, None))
             }
         } else {
-            if colour_encoding.is_srgb() {
-                encoder.set_srgb(match colour_encoding.rendering_intent {
-                    RenderingIntent::Perceptual => png::SrgbRenderingIntent::Perceptual,
-                    RenderingIntent::Relative => png::SrgbRenderingIntent::RelativeColorimetric,
-                    RenderingIntent::Saturation => png::SrgbRenderingIntent::Saturation,
-                    RenderingIntent::Absolute => png::SrgbRenderingIntent::AbsoluteColorimetric,
-                });
-            }
-
             // TODO: emit gAMA and cHRM
             Some((&*source_icc, cicp))
         };


### PR DESCRIPTION
ICC profiles are used instead of sRGB chunks.