### PR TITLE
jxl-oxide: Merge JxlRenderer into JxlImage

### DIFF
--- a/crates/jxl-oxide-cli/src/bin/jxl-dec.rs
+++ b/crates/jxl-oxide-cli/src/bin/jxl-dec.rs
@@ -158,12 +158,11 @@ fn main() {
     let decode_start = std::time::Instant::now();
 
     let mut keyframes = Vec::new();
-    let mut renderer = image.renderer();
     if args.output_format == OutputFormat::Npy {
-        renderer.set_render_spot_colour(false);
+        image.set_render_spot_colour(false);
     }
     loop {
-        let result = renderer.render_next_frame_cropped(crop).expect("rendering frames failed");
+        let result = image.render_next_frame_cropped(crop).expect("rendering frames failed");
         match result {
             jxl_oxide::RenderResult::Done(frame) => keyframes.push(frame),
             jxl_oxide::RenderResult::NeedMoreData => panic!("Unexpected end of file"),
@@ -177,7 +176,7 @@ fn main() {
 
     if let Some(output) = &args.output {
         tracing::debug!(output_format = format_args!("{:?}", args.output_format));
-        let pixel_format = renderer.pixel_format();
+        let pixel_format = image.pixel_format();
         let output = std::fs::File::create(output).expect("failed to open output file");
         match args.output_format {
             OutputFormat::Png => {

--- a/crates/jxl-oxide-cli/src/bin/jxl-info.rs
+++ b/crates/jxl-oxide-cli/src/bin/jxl-info.rs
@@ -102,13 +102,12 @@ fn main() {
     }
 
     let animated = image_meta.animation.is_some();
-    let mut renderer = image.renderer();
     loop {
-        let result = renderer.load_next_frame().expect("rendering frames failed");
+        let result = image.load_next_frame().expect("loading frames failed");
         let frame_header = match result {
             jxl_oxide::LoadResult::Done(idx) => {
                 println!("Frame #{idx}");
-                renderer.frame_header(idx).unwrap()
+                image.frame_header(idx).unwrap()
             }
             jxl_oxide::LoadResult::NeedMoreData => panic!("Unexpected end of file"),
             jxl_oxide::LoadResult::NoMoreFrames => break,

--- a/crates/jxl-oxide/src/bin/generate-fixture.rs
+++ b/crates/jxl-oxide/src/bin/generate-fixture.rs
@@ -14,9 +14,8 @@ fn main() {
     header[8..12].copy_from_slice(&channels.to_le_bytes());
     stdout.write_all(&header).unwrap();
 
-    let mut renderer = image.renderer();
     loop {
-        let result = renderer.render_next_frame().unwrap();
+        let result = image.render_next_frame().unwrap();
         match result {
             jxl_oxide::RenderResult::Done(frame) => {
                 stdout.write_all(&[0]).unwrap();

--- a/crates/jxl-oxide/tests/conformance.rs
+++ b/crates/jxl-oxide/tests/conformance.rs
@@ -75,14 +75,13 @@ fn run_test<R: std::io::Read>(
 ) {
     let debug = std::env::var("JXL_OXIDE_DEBUG").is_ok();
 
-    let mut renderer = image.renderer();
-    renderer.set_render_spot_colour(false);
+    image.set_render_spot_colour(false);
 
     let transform = target_icc.map(|target_icc| {
-        let source_profile = Profile::new_icc(&renderer.rendered_icc()).expect("failed to parse ICC profile");
+        let source_profile = Profile::new_icc(&image.rendered_icc()).expect("failed to parse ICC profile");
         let target_profile = Profile::new_icc(&target_icc).expect("failed to parse ICC profile");
 
-        if renderer.image_header().metadata.grayscale() {
+        if image.image_header().metadata.grayscale() {
             LcmsTransform::Grayscale(Transform::new(
                 &source_profile,
                 lcms2::PixelFormat::GRAY_FLT,
@@ -103,7 +102,7 @@ fn run_test<R: std::io::Read>(
 
     let mut num_keyframes = 0usize;
     loop {
-        let result = renderer.render_next_frame().expect("failed to render frame");
+        let result = image.render_next_frame().expect("failed to render frame");
         let render = match result {
             jxl_oxide::RenderResult::Done(render) => render,
             jxl_oxide::RenderResult::NeedMoreData => panic!("unexpected end of file"),

--- a/crates/jxl-oxide/tests/decode.rs
+++ b/crates/jxl-oxide/tests/decode.rs
@@ -26,10 +26,9 @@ fn decode<R: Read>(data: &[u8], mut expected: R) {
     let fixture_header = FixtureHeader::from_bytes(header);
 
     let mut image = jxl_oxide::JxlImage::from_reader(std::io::Cursor::new(data)).unwrap();
-    let mut renderer = image.renderer();
 
     loop {
-        let result = renderer.render_next_frame().unwrap();
+        let result = image.render_next_frame().unwrap();
         match result {
             jxl_oxide::RenderResult::Done(frame) => {
                 let mut marker = 0u8;


### PR DESCRIPTION
Now users don't need to deal with lifetime parameters since `JxlRenderer` doesn't exist anymore. All the methods of `JxlRenderer` is merged into `JxlImage`.

This change was possible because single `RenderContext` can be reused for multiple renders of an image, due to recent patches to `jxl-render`.