### PR TITLE
jxl-oxide-cli: Apply orientation to reported image dimension

### DIFF
--- a/crates/jxl-image/src/lib.rs
+++ b/crates/jxl-image/src/lib.rs
@@ -66,6 +66,20 @@ impl<Ctx> Bundle<Ctx> for ImageHeader {
     }
 }
 
+impl ImageHeader {
+    /// Returns the image width with orientation applied.
+    #[inline]
+    pub fn width_with_orientation(&self) -> u32 {
+        self.metadata.apply_orientation(self.size.width, self.size.height, 0, 0, false).0
+    }
+
+    /// Returns the image height with orientation applied.
+    #[inline]
+    pub fn height_with_orientation(&self) -> u32 {
+        self.metadata.apply_orientation(self.size.width, self.size.height, 0, 0, false).1
+    }
+}
+
 define_bundle! {
     /// Image size information.
     #[derive(Debug)]

--- a/crates/jxl-oxide-cli/src/bin/jxl-dec.rs
+++ b/crates/jxl-oxide-cli/src/bin/jxl-dec.rs
@@ -122,7 +122,7 @@ fn main() {
     let mut image = JxlImage::open(&args.input).expect("Failed to open file");
     let image_size = &image.image_header().size;
     let image_meta = &image.image_header().metadata;
-    tracing::info!("Image dimension: {}x{}", image_size.width, image_size.height);
+    tracing::info!("Image dimension: {}x{}", image.width(), image.height());
     tracing::debug!(colour_encoding = format_args!("{:?}", image_meta.colour_encoding));
 
     if let Some(icc_path) = &args.icc_output {

--- a/crates/jxl-oxide-cli/src/bin/jxl-info.rs
+++ b/crates/jxl-oxide-cli/src/bin/jxl-info.rs
@@ -37,7 +37,23 @@ fn main() {
     let image_meta = &image.image_header().metadata;
 
     println!("JPEG XL image");
-    println!("  Image dimension: {}x{}", image_size.width, image_size.height);
+
+    println!("  Image dimension: {}x{}", image.width(), image.height());
+    if image_meta.orientation != 1 {
+        println!("    Encoded image dimension: {}x{}", image_size.width, image_size.height);
+        print!("    Orientation of encoded image: ");
+        match image_meta.orientation {
+            2 => println!("flipped horizontally"),
+            3 => println!("rotated 180 degrees"),
+            4 => println!("flipped vertically"),
+            5 => println!("transposed"),
+            6 => println!("rotated 90 degrees CCW"),
+            7 => println!("rotated 90 degrees CCW, and then flipped horizontally"),
+            8 => println!("rotated 90 degrees CW"),
+            _ => {},
+        }
+    }
+
     println!("  Bit depth: {} bits", image_meta.bit_depth.bits_per_sample());
     if image_meta.xyb_encoded {
         println!("  XYB encoded, suggested display color encoding:");

--- a/crates/jxl-oxide/src/lib.rs
+++ b/crates/jxl-oxide/src/lib.rs
@@ -140,6 +140,18 @@ impl<R> JxlImage<R> {
         &self.image_header
     }
 
+    /// Returns the image width with orientation applied.
+    #[inline]
+    pub fn width(&self) -> u32 {
+        self.image_header.width_with_orientation()
+    }
+
+    /// Returns the image height with orientation applied.
+    #[inline]
+    pub fn height(&self) -> u32 {
+        self.image_header.height_with_orientation()
+    }
+
     /// Returns the embedded ICC profile.
     #[inline]
     pub fn embedded_icc(&self) -> Option<&[u8]> {


### PR DESCRIPTION
Fixes #63.

```console
$ jxl-info sunset_logo.jxl
JPEG XL image
  Image dimension: 924x1386
    Encoded image dimension: 1386x924
    Orientation of encoded image: rotated 90 degrees CCW, and then flipped horizontally
  Bit depth: 10 bits
  Color encoding:
    Colorspace: RGB
    White point: D65
    Primaries: sRGB
    Transfer function: sRGB
(... snip ...)
```