### PR TITLE
jxl-oxide: Add note to `embedded_icc`

### DIFF
--- a/crates/jxl-oxide/src/lib.rs
+++ b/crates/jxl-oxide/src/lib.rs
@@ -153,6 +153,9 @@ impl<R> JxlImage<R> {
     }
 
     /// Returns the embedded ICC profile.
+    ///
+    /// It does *not* describe the colorspace of rendered images. Use
+    /// [`rendered_icc`][Self::rendered_icc] to do color management.
     #[inline]
     pub fn embedded_icc(&self) -> Option<&[u8]> {
         self.embedded_icc.as_deref()


### PR DESCRIPTION
`rendered_icc` should be used in most cases.