### PR TITLE
jxl-oxide v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,16 +28,15 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
  "utf8parse",
 ]
 
@@ -67,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -121,6 +120,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
+name = "bytemuck"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+
+[[package]]
 name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,20 +148,19 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.3.17"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0827b011f6f8ab38590295339817b0d26f344aa4932c3ced71b45b0c54b4a9"
+checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.17"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9441b403be87be858db6a23edb493e7f694761acdc3343d5a0fcaafd304cbc9e"
+checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
 dependencies = [
  "anstream",
  "anstyle",
@@ -166,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.12"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -531,17 +535,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,7 +628,7 @@ dependencies = [
  "jxl-grid",
  "jxl-image",
  "jxl-render",
- "lcms2",
+ "lcms2 5.6.0",
  "rand",
  "reqwest",
  "tracing",
@@ -648,7 +641,7 @@ version = "0.2.3"
 dependencies = [
  "clap",
  "jxl-oxide",
- "lcms2",
+ "lcms2 6.0.0",
  "miniz_oxide",
  "png",
  "tracing",
@@ -698,10 +691,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "lcms2-sys"
-version = "4.0.1"
+name = "lcms2"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abb8aac1a07fd8cdffaa25461a3873a7bf7164cd20b849d44a183a1348d682f"
+checksum = "897a7716b253bb5c58ac17a1a74ddda694f57fcf1c8a65799087783592c71092"
+dependencies = [
+ "bytemuck",
+ "foreign-types 0.5.0",
+ "lcms2-sys",
+]
+
+[[package]]
+name = "lcms2-sys"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "137dae56197ab9e66729ff73e2942e26f16f9ddcd14a53295c35f53dcd067b58"
 dependencies = [
  "cc",
  "dunce",
@@ -898,9 +902,9 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "png"
-version = "0.17.9"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59871cc5b6cce7eaccca5a802b4173377a1c2ba90654246789a8fa2334426d11"
+checksum = "dd75bf2d8dd3702b9707cdbc56a5b9ef42cec752eb8b3bafc01234558442aa64"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "jxl-frame"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
@@ -607,7 +607,7 @@ version = "0.1.1"
 
 [[package]]
 name = "jxl-image"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "jxl-bitstream",
  "jxl-color",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "jxl-modular"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "jxl-oxide"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "jxl-bitstream",
  "jxl-color",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "jxl-oxide-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "clap",
  "jxl-oxide",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "jxl-render"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "jxl-vardct"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
  "jxl-grid",
  "jxl-image",
  "jxl-render",
- "lcms2 5.6.0",
+ "lcms2",
  "rand",
  "reqwest",
  "tracing",
@@ -641,7 +641,7 @@ version = "0.2.3"
 dependencies = [
  "clap",
  "jxl-oxide",
- "lcms2 6.0.0",
+ "lcms2",
  "miniz_oxide",
  "png",
  "tracing",
@@ -679,16 +679,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "lcms2"
-version = "5.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d50a4d00d909da0ec023ab34ea09bf3b3b79b5a36b3e0da3a305112edaf150"
-dependencies = [
- "foreign-types 0.5.0",
- "lcms2-sys",
-]
 
 [[package]]
 name = "lcms2"
@@ -1004,9 +994,9 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "reqwest"
-version = "0.11.18"
+version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
  "base64",
  "bytes",
@@ -1554,11 +1544,12 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you want to use it as a library, specify it in `Cargo.toml`:
 
 ```toml
 [dependencies]
-jxl-oxide = "0.3.0"
+jxl-oxide = "0.4.0"
 ```
 
 Note that you'll need a color management system to correctly display some JXL images. (`jxl-dec`

--- a/crates/jxl-frame/Cargo.toml
+++ b/crates/jxl-frame/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jpeg-xl", "decoder", "jxl-oxide"]
 categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 [dependencies]
@@ -18,7 +18,7 @@ version = "0.2.3"
 path = "../jxl-bitstream"
 
 [dependencies.jxl-coding]
-version = "0.2.0"
+version = "0.2.3"
 path = "../jxl-coding"
 
 [dependencies.jxl-grid]
@@ -26,15 +26,15 @@ version = "0.1.1"
 path = "../jxl-grid"
 
 [dependencies.jxl-image]
-version = "0.4.0"
+version = "0.5.0"
 path = "../jxl-image"
 
 [dependencies.jxl-modular]
-version = "0.2.0"
+version = "0.3.0"
 path = "../jxl-modular"
 
 [dependencies.jxl-vardct]
-version = "0.2.0"
+version = "0.3.0"
 path = "../jxl-vardct"
 
 [dependencies.tracing]

--- a/crates/jxl-image/Cargo.toml
+++ b/crates/jxl-image/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jpeg-xl", "decoder", "jxl-oxide"]
 categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/jxl-modular/Cargo.toml
+++ b/crates/jxl-modular/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jpeg-xl", "decoder", "jxl-oxide"]
 categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]
@@ -22,7 +22,7 @@ version = "0.2.3"
 path = "../jxl-coding"
 
 [dependencies.jxl-grid]
-version = "0.1.0"
+version = "0.1.1"
 path = "../jxl-grid"
 
 [dependencies.tracing]

--- a/crates/jxl-oxide-cli/Cargo.toml
+++ b/crates/jxl-oxide-cli/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jpeg-xl", "decoder", "jxl-oxide"]
 categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [dependencies]
@@ -21,7 +21,7 @@ version = "4.3.4"
 features = ["derive"]
 
 [dependencies.jxl-oxide]
-version = "0.3.0"
+version = "0.4.0"
 path = "../jxl-oxide"
 
 [dependencies.tracing]

--- a/crates/jxl-oxide-cli/Cargo.toml
+++ b/crates/jxl-oxide-cli/Cargo.toml
@@ -12,12 +12,12 @@ version = "0.2.3"
 edition = "2021"
 
 [dependencies]
-lcms2 = "5.6.0"
+lcms2 = "6.0.0"
 miniz_oxide = "0.7.1"
-png = "0.17.9"
+png = "0.17.10"
 
 [dependencies.clap]
-version = "4.3.4"
+version = "4.4.2"
 features = ["derive"]
 
 [dependencies.jxl-oxide]
@@ -30,5 +30,5 @@ default_features = false
 features = ["std"]
 
 [dependencies.tracing-subscriber]
-version = "0.3.16"
+version = "0.3.17"
 features = ["env-filter"]

--- a/crates/jxl-oxide/Cargo.toml
+++ b/crates/jxl-oxide/Cargo.toml
@@ -45,8 +45,8 @@ default_features = false
 features = ["std"]
 
 [dev-dependencies]
-lcms2 = "5.5.0"
-zstd = "0.12.3"
+lcms2 = "6.0.0"
+zstd = "0.12.4"
 
 [dev-dependencies.rand]
 version = "0.8.5"
@@ -54,5 +54,5 @@ default_features = false
 features = ["getrandom", "small_rng"]
 
 [dev-dependencies.reqwest]
-version = "0.11.14"
+version = "0.11.20"
 features = ["blocking"]

--- a/crates/jxl-oxide/Cargo.toml
+++ b/crates/jxl-oxide/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jpeg-xl", "decoder", "jxl-oxide"]
 categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 exclude = ["tests/"]
@@ -24,7 +24,7 @@ version = "0.3.2"
 path = "../jxl-color"
 
 [dependencies.jxl-frame]
-version = "0.4.0"
+version = "0.5.0"
 path = "../jxl-frame"
 
 [dependencies.jxl-grid]
@@ -32,11 +32,11 @@ version = "0.1.1"
 path = "../jxl-grid"
 
 [dependencies.jxl-image]
-version = "0.4.1"
+version = "0.5.0"
 path = "../jxl-image"
 
 [dependencies.jxl-render]
-version = "0.3.0"
+version = "0.4.0"
 path = "../jxl-render"
 
 [dependencies.tracing]

--- a/crates/jxl-render/Cargo.toml
+++ b/crates/jxl-render/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jpeg-xl", "decoder", "jxl-oxide"]
 categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]
@@ -18,15 +18,15 @@ version = "0.2.3"
 path = "../jxl-bitstream"
 
 [dependencies.jxl-coding]
-version = "0.2.0"
+version = "0.2.3"
 path = "../jxl-coding"
 
 [dependencies.jxl-color]
-version = "0.3.0"
+version = "0.3.2"
 path = "../jxl-color"
 
 [dependencies.jxl-frame]
-version = "0.4.0"
+version = "0.5.0"
 path = "../jxl-frame"
 
 [dependencies.jxl-grid]
@@ -34,15 +34,15 @@ version = "0.1.1"
 path = "../jxl-grid"
 
 [dependencies.jxl-image]
-version = "0.4.0"
+version = "0.5.0"
 path = "../jxl-image"
 
 [dependencies.jxl-modular]
-version = "0.2.0"
+version = "0.3.0"
 path = "../jxl-modular"
 
 [dependencies.jxl-vardct]
-version = "0.2.0"
+version = "0.3.0"
 path = "../jxl-vardct"
 
 [dependencies.tracing]

--- a/crates/jxl-vardct/Cargo.toml
+++ b/crates/jxl-vardct/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jpeg-xl", "decoder", "jxl-oxide"]
 categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]
@@ -18,7 +18,7 @@ version = "0.2.3"
 path = "../jxl-bitstream"
 
 [dependencies.jxl-coding]
-version = "0.2.0"
+version = "0.2.3"
 path = "../jxl-coding"
 
 [dependencies.jxl-grid]
@@ -26,7 +26,7 @@ version = "0.1.1"
 path = "../jxl-grid"
 
 [dependencies.jxl-modular]
-version = "0.2.0"
+version = "0.3.0"
 path = "../jxl-modular"
 
 [dependencies.tracing]


### PR DESCRIPTION
Updated crates:
- `jxl-image` 0.5.0
- `jxl-modular` 0.3.0
- `jxl-vardct` 0.3.0
- `jxl-frame` 0.5.0
- `jxl-render` 0.4.0
- `jxl-oxide` 0.4.0
- `jxl-oxide-cli` 0.2.3
  - CLI is backwards compatible