### PR TITLE
jxl-render: Improve EPF performance

### DIFF
--- a/crates/jxl-render/src/filter/epf.rs
+++ b/crates/jxl-render/src/filter/epf.rs
@@ -28,22 +28,24 @@ pub fn apply_epf(
 
     let width = region.width as usize;
     let height = region.height as usize;
-    // Extra padding for SIMD
+    // Mirror padding, extra padding for SIMD
+    let padded_width = (width + 8 + 3 + 7) & !7;
+    let padded_height = height + 6;
     let mut fb_in = [
-        SimpleGrid::new(width + 6, height + 7),
-        SimpleGrid::new(width + 6, height + 7),
-        SimpleGrid::new(width + 6, height + 7),
+        SimpleGrid::new(padded_width, padded_height),
+        SimpleGrid::new(padded_width, padded_height),
+        SimpleGrid::new(padded_width, padded_height),
     ];
     let mut fb_out = [
-        SimpleGrid::new(width + 6, height + 7),
-        SimpleGrid::new(width + 6, height + 7),
-        SimpleGrid::new(width + 6, height + 7),
+        SimpleGrid::new(padded_width, padded_height),
+        SimpleGrid::new(padded_width, padded_height),
+        SimpleGrid::new(padded_width, padded_height),
     ];
     for (output, input) in fb_in.iter_mut().zip(&*fb) {
         let output = output.buf_mut();
         let input = input.buf();
         for y in 0..height {
-            output[(y + 3) * (width + 6) + 3..][..width].copy_from_slice(&input[y * width..][..width]);
+            output[(y + 3) * padded_width + 8..][..width].copy_from_slice(&input[y * width..][..width]);
         }
     }
 
@@ -98,23 +100,23 @@ pub fn apply_epf(
         for output in &mut fb_in {
             let output = output.buf_mut();
 
-            for y in 3..height + 3 {
-                output[y * (width + 6)] = output[y * (width + 6) + 5];
-                output[y * (width + 6) + 1] = output[y * (width + 6) + 4];
-                output[y * (width + 6) + 2] = output[y * (width + 6) + 3];
-                output[(y + 1) * (width + 6) - 3] = output[(y + 1) * (width + 6) - 4];
-                output[(y + 1) * (width + 6) - 2] = output[(y + 1) * (width + 6) - 5];
-                output[(y + 1) * (width + 6) - 1] = output[(y + 1) * (width + 6) - 6];
+            for row in output.chunks_exact_mut(padded_width).skip(3).take(height) {
+                row[7] = row[8];
+                row[8 + width] = row[8 + width - 1];
+                row[6] = row[9];
+                row[8 + width + 1] = row[8 + width - 2];
+                row[5] = row[10];
+                row[8 + width + 2] = row[8 + width - 3];
             }
 
-            let (out_chunk, in_chunk) = output.split_at_mut((width + 6) * 3);
-            let in_chunk = &in_chunk[..(width + 6) * 3];
-            for (out_row, in_row) in out_chunk.chunks_exact_mut(width + 6).zip(in_chunk.chunks_exact(width + 6).rev()) {
+            let (out_chunk, in_chunk) = output.split_at_mut(padded_width * 3);
+            let in_chunk = &in_chunk[..padded_width * 3];
+            for (out_row, in_row) in out_chunk.chunks_exact_mut(padded_width).zip(in_chunk.chunks_exact(padded_width).rev()) {
                 out_row.copy_from_slice(in_row);
             }
 
-            let (in_chunk, out_chunk) = output.split_at_mut((width + 6) * (height + 3));
-            for (out_row, in_row) in out_chunk.chunks_exact_mut(width + 6).zip(in_chunk.chunks_exact(width + 6).rev()) {
+            let (in_chunk, out_chunk) = output.split_at_mut(padded_width * (height + 3));
+            for (out_row, in_row) in out_chunk.chunks_exact_mut(padded_width).zip(in_chunk.chunks_exact(padded_width).rev()) {
                 out_row.copy_from_slice(in_row);
             }
         }
@@ -136,23 +138,23 @@ pub fn apply_epf(
         for output in &mut fb_in {
             let output = output.buf_mut();
 
-            for y in 3..height + 3 {
-                output[y * (width + 6)] = output[y * (width + 6) + 5];
-                output[y * (width + 6) + 1] = output[y * (width + 6) + 4];
-                output[y * (width + 6) + 2] = output[y * (width + 6) + 3];
-                output[(y + 1) * (width + 6) - 3] = output[(y + 1) * (width + 6) - 4];
-                output[(y + 1) * (width + 6) - 2] = output[(y + 1) * (width + 6) - 5];
-                output[(y + 1) * (width + 6) - 1] = output[(y + 1) * (width + 6) - 6];
+            for row in output.chunks_exact_mut(padded_width).skip(3).take(height) {
+                row[7] = row[8];
+                row[8 + width] = row[8 + width - 1];
+                row[6] = row[9];
+                row[8 + width + 1] = row[8 + width - 2];
+                row[5] = row[10];
+                row[8 + width + 2] = row[8 + width - 3];
             }
 
-            let (out_chunk, in_chunk) = output.split_at_mut((width + 6) * 3);
-            let in_chunk = &in_chunk[..(width + 6) * 3];
-            for (out_row, in_row) in out_chunk.chunks_exact_mut(width + 6).zip(in_chunk.chunks_exact(width + 6).rev()) {
+            let (out_chunk, in_chunk) = output.split_at_mut(padded_width * 3);
+            let in_chunk = &in_chunk[..padded_width * 3];
+            for (out_row, in_row) in out_chunk.chunks_exact_mut(padded_width).zip(in_chunk.chunks_exact(padded_width).rev()) {
                 out_row.copy_from_slice(in_row);
             }
 
-            let (in_chunk, out_chunk) = output.split_at_mut((width + 6) * (height + 3));
-            for (out_row, in_row) in out_chunk.chunks_exact_mut(width + 6).zip(in_chunk.chunks_exact(width + 6).rev()) {
+            let (in_chunk, out_chunk) = output.split_at_mut(padded_width * (height + 3));
+            for (out_row, in_row) in out_chunk.chunks_exact_mut(padded_width).zip(in_chunk.chunks_exact(padded_width).rev()) {
                 out_row.copy_from_slice(in_row);
             }
         }
@@ -174,23 +176,23 @@ pub fn apply_epf(
         for output in &mut fb_in {
             let output = output.buf_mut();
 
-            for y in 3..height + 3 {
-                output[y * (width + 6)] = output[y * (width + 6) + 5];
-                output[y * (width + 6) + 1] = output[y * (width + 6) + 4];
-                output[y * (width + 6) + 2] = output[y * (width + 6) + 3];
-                output[(y + 1) * (width + 6) - 3] = output[(y + 1) * (width + 6) - 4];
-                output[(y + 1) * (width + 6) - 2] = output[(y + 1) * (width + 6) - 5];
-                output[(y + 1) * (width + 6) - 1] = output[(y + 1) * (width + 6) - 6];
+            for row in output.chunks_exact_mut(padded_width).skip(3).take(height) {
+                row[7] = row[8];
+                row[8 + width] = row[8 + width - 1];
+                row[6] = row[9];
+                row[8 + width + 1] = row[8 + width - 2];
+                row[5] = row[10];
+                row[8 + width + 2] = row[8 + width - 3];
             }
 
-            let (out_chunk, in_chunk) = output.split_at_mut((width + 6) * 3);
-            let in_chunk = &in_chunk[..(width + 6) * 3];
-            for (out_row, in_row) in out_chunk.chunks_exact_mut(width + 6).zip(in_chunk.chunks_exact(width + 6).rev()) {
+            let (out_chunk, in_chunk) = output.split_at_mut(padded_width * 3);
+            let in_chunk = &in_chunk[..padded_width * 3];
+            for (out_row, in_row) in out_chunk.chunks_exact_mut(padded_width).zip(in_chunk.chunks_exact(padded_width).rev()) {
                 out_row.copy_from_slice(in_row);
             }
 
-            let (in_chunk, out_chunk) = output.split_at_mut((width + 6) * (height + 3));
-            for (out_row, in_row) in out_chunk.chunks_exact_mut(width + 6).zip(in_chunk.chunks_exact(width + 6).rev()) {
+            let (in_chunk, out_chunk) = output.split_at_mut(padded_width * (height + 3));
+            for (out_row, in_row) in out_chunk.chunks_exact_mut(padded_width).zip(in_chunk.chunks_exact(padded_width).rev()) {
                 out_row.copy_from_slice(in_row);
             }
         }
@@ -210,7 +212,7 @@ pub fn apply_epf(
         let output = output.buf_mut();
         let input = input.buf();
         for y in 0..height {
-            output[y * width..][..width].copy_from_slice(&input[(y + 3) * (width + 6) + 3..][..width]);
+            output[y * width..][..width].copy_from_slice(&input[(y + 3) * padded_width + 8..][..width]);
         }
     }
 }

--- a/crates/jxl-render/src/filter/impls/generic.rs
+++ b/crates/jxl-render/src/filter/impls/generic.rs
@@ -6,146 +6,121 @@ fn weight(scaled_distance: f32, sigma: f32, step_multiplier: f32) -> f32 {
     (1.0 - scaled_distance * inv_sigma).max(0.0)
 }
 
-#[allow(clippy::too_many_arguments)]
-fn epf_step(
-    input: &[SimpleGrid<f32>; 3],
-    output: &mut [SimpleGrid<f32>; 3],
-    sigma_grid: &SimpleGrid<f32>,
-    channel_scale: [f32; 3],
-    border_sad_mul: f32,
-    step_multiplier: f32,
-    kernel_coords: &'static [(isize, isize)],
-    dist_coords: &'static [(isize, isize)],
-) {
-    let width = input[0].width();
-    let height = input[0].height();
-    for y in 0..height - 7 {
-        let y8 = y / 8;
-        let is_y_border = (y % 8) == 0 || (y % 8) == 7;
-        let y = y + 3;
+macro_rules! define_epf {
+    { $($v:vis fn $name:ident ($width:ident, $kernel_offsets:expr, $dist_offsets:expr $(,)?); )* } => {
+        $(
+            $v fn $name(
+                input: &[SimpleGrid<f32>; 3],
+                output: &mut [SimpleGrid<f32>; 3],
+                sigma_grid: &SimpleGrid<f32>,
+                channel_scale: [f32; 3],
+                border_sad_mul: f32,
+                step_multiplier: f32,
+            ) {
+                let width = input[0].width();
+                let $width = width as isize;
+                let height = input[0].height();
+                let height = height - 6;
+                for y in 0..height {
+                    let y8 = y / 8;
+                    let is_y_border = (y % 8) == 0 || (y % 8) == 7;
+                    let sm = if is_y_border {
+                        [border_sad_mul * step_multiplier; 8]
+                    } else {
+                        [
+                            border_sad_mul * step_multiplier,
+                            step_multiplier,
+                            step_multiplier,
+                            step_multiplier,
+                            step_multiplier,
+                            step_multiplier,
+                            step_multiplier,
+                            border_sad_mul * step_multiplier,
+                        ]
+                    };
 
-        for x in 0..width - 6 {
-            let x8 = x / 8;
-            let is_border = is_y_border || (x % 8) == 0 || (x % 8) == 7;
-            let x = x + 3;
+                    for x8 in 1..width / 8 {
+                        let base_x = x8 * 8;
+                        let base_idx = (y + 3) * width + base_x;
 
-            let sigma_val = *sigma_grid.get(x8, y8).unwrap();
-            if sigma_val < 0.3 {
-                for (input, ch) in input.iter().zip(output.iter_mut()) {
-                    let input_ch = input.buf();
-                    let output_ch = ch.buf_mut();
-                    output_ch[y * width + x] = input_ch[y * width + x];
-                }
-                continue;
-            }
+                        let Some(&sigma_val) = sigma_grid.get(x8 - 1, y8) else { break; };
+                        if sigma_val < 0.3 {
+                            for (input, ch) in input.iter().zip(output.iter_mut()) {
+                                let input_ch = input.buf();
+                                let output_ch = ch.buf_mut();
+                                output_ch[base_idx..][..8].copy_from_slice(&input_ch[base_idx..][..8]);
+                            }
+                            continue;
+                        }
 
-            let mut sum_weights = 1.0f32;
-            let mut sum_channels = [0.0f32; 3];
-            for (sum, ch) in sum_channels.iter_mut().zip(input) {
-                let ch = ch.buf();
-                *sum = ch[y * width + x];
-            }
+                        for (dx, sm) in sm.into_iter().enumerate() {
+                            let base_idx = base_idx + dx;
 
-            for &(dx, dy) in kernel_coords {
-                let tx = x as isize + dx;
-                let ty = y as isize + dy;
-                let mut dist = 0.0f32;
-                for (ch, scale) in input.iter().zip(channel_scale) {
-                    let ch = ch.buf();
-                    for &(dx, dy) in dist_coords {
-                        let x = x as isize + dx;
-                        let y = y as isize + dy;
-                        let tx = (tx + dx) as usize;
-                        let ty = (ty + dy) as usize;
-                        let x = x as usize;
-                        let y = y as usize;
-                        dist += (ch[y * width + x] - ch[ty * width + tx]).abs() * scale;
+                            let mut sum_weights = 1.0f32;
+                            let mut sum_channels = [0.0f32; 3];
+                            for (sum, ch) in sum_channels.iter_mut().zip(input) {
+                                let ch = ch.buf();
+                                *sum = ch[base_idx];
+                            }
+
+                            for offset in $kernel_offsets {
+                                let kernel_idx = base_idx.wrapping_add_signed(offset);
+                                let mut dist = 0.0f32;
+                                for (ch, scale) in input.iter().zip(channel_scale) {
+                                    let ch = ch.buf();
+                                    for offset in $dist_offsets {
+                                        let base_idx = base_idx.wrapping_add_signed(offset);
+                                        let kernel_idx = kernel_idx.wrapping_add_signed(offset);
+                                        dist += (ch[base_idx] - ch[kernel_idx]).abs() * scale;
+                                    }
+                                }
+
+                                let weight = weight(
+                                    dist,
+                                    sigma_val,
+                                    sm,
+                                );
+                                sum_weights += weight;
+
+                                for (sum, ch) in sum_channels.iter_mut().zip(input) {
+                                    let ch = ch.buf();
+                                    *sum += ch[kernel_idx] * weight;
+                                }
+                            }
+
+                            for (sum, ch) in sum_channels.into_iter().zip(output.iter_mut()) {
+                                let ch = ch.buf_mut();
+                                ch[base_idx] = sum / sum_weights;
+                            }
+                        }
                     }
                 }
-
-                let weight = weight(
-                    dist,
-                    sigma_val,
-                    step_multiplier * if is_border { border_sad_mul } else { 1.0 },
-                );
-                sum_weights += weight;
-
-                let tx = tx as usize;
-                let ty = ty as usize;
-                for (sum, ch) in sum_channels.iter_mut().zip(input) {
-                    let ch = ch.buf();
-                    *sum += ch[ty * width + tx] * weight;
-                }
             }
-
-            for (sum, ch) in sum_channels.into_iter().zip(output.iter_mut()) {
-                let ch = ch.buf_mut();
-                ch[y * width + x] = sum / sum_weights;
-            }
-        }
-    }
+        )*
+    };
 }
 
-pub fn epf_step0(
-    input: &[SimpleGrid<f32>; 3],
-    output: &mut [SimpleGrid<f32>; 3],
-    sigma_grid: &SimpleGrid<f32>,
-    channel_scale: [f32; 3],
-    border_sad_mul: f32,
-    step_multiplier: f32,
-) {
-    epf_step(
-        input,
-        output,
-        sigma_grid,
-        channel_scale,
-        border_sad_mul,
-        step_multiplier,
-        &[
-            (0, -1), (-1, 0), (1, 0), (0, 1),
-            (0, -2), (-1, -1), (1, -1), (-2, 0), (2, 0), (-1, 1), (1, 1), (0, 2),
+define_epf! {
+    pub fn epf_step0(
+        width,
+        [
+            -2 * width,
+            -1 - width, -width, 1 - width,
+            -2, -1, 1, 2,
+            width - 1, width, width + 1,
+            2 * width,
         ],
-        &[(0, 0), (0, -1), (-1, 0), (1, 0), (0, 1)],
+        [-width, -1, 0, 1, width],
     );
-}
-
-pub fn epf_step1(
-    input: &[SimpleGrid<f32>; 3],
-    output: &mut [SimpleGrid<f32>; 3],
-    sigma_grid: &SimpleGrid<f32>,
-    channel_scale: [f32; 3],
-    border_sad_mul: f32,
-    step_multiplier: f32,
-) {
-    epf_step(
-        input,
-        output,
-        sigma_grid,
-        channel_scale,
-        border_sad_mul,
-        step_multiplier,
-        &[(0, -1), (-1, 0), (1, 0), (0, 1)],
-        &[(0, 0), (0, -1), (-1, 0), (1, 0), (0, 1)],
+    pub fn epf_step1(
+        width,
+        [-width, -1, 1, width],
+        [-width, -1, 0, 1, width],
     );
-}
-
-pub fn epf_step2(
-    input: &[SimpleGrid<f32>; 3],
-    output: &mut [SimpleGrid<f32>; 3],
-    sigma_grid: &SimpleGrid<f32>,
-    channel_scale: [f32; 3],
-    border_sad_mul: f32,
-    step_multiplier: f32,
-) {
-    epf_step(
-        input,
-        output,
-        sigma_grid,
-        channel_scale,
-        border_sad_mul,
-        step_multiplier,
-        &[(0, -1), (-1, 0), (1, 0), (0, 1)],
-        &[(0, 0)],
+    pub fn epf_step2(
+        width,
+        [-width, -1, 1, width],
+        [0isize],
     );
 }
 

--- a/crates/jxl-render/src/filter/impls/x86_64/epf_avx2.rs
+++ b/crates/jxl-render/src/filter/impls/x86_64/epf_avx2.rs
@@ -96,7 +96,8 @@ macro_rules! define_epf_avx2 {
                                 for offset in $dist_offsets {
                                     let base_idx = base_idx.wrapping_add_signed(offset);
                                     let kernel_idx = kernel_idx.wrapping_add_signed(offset);
-                                    dist = scale.muladd(
+                                    dist = _mm256_fmadd_ps(
+                                        scale,
                                         Vector::load(buf.as_ptr().add(base_idx)).sub(
                                             Vector::load(buf.as_ptr().add(kernel_idx))
                                         ).abs(),
@@ -113,7 +114,11 @@ macro_rules! define_epf_avx2 {
                             sum_weights = sum_weights.add(weight);
 
                             for (sum, buf) in sum_channels.iter_mut().zip(input_buf) {
-                                *sum = weight.muladd(Vector::load(buf.as_ptr().add(kernel_idx)), *sum);
+                                *sum = _mm256_fmadd_ps(
+                                    weight,
+                                    Vector::load(buf.as_ptr().add(kernel_idx)),
+                                    *sum,
+                                );
                             }
                         }
 

--- a/crates/jxl-render/src/filter/impls/x86_64/epf_avx2.rs
+++ b/crates/jxl-render/src/filter/impls/x86_64/epf_avx2.rs
@@ -19,7 +19,7 @@ unsafe fn weight_avx2(scaled_distance: Vector, sigma: f32, step_multiplier: Vect
 }
 
 macro_rules! define_epf_avx2 {
-    { $($v:vis unsafe fn $name:ident ($width:ident, $kernel_diff:expr, $dist_diff:expr $(,)?); )* } => {
+    { $($v:vis unsafe fn $name:ident ($width:ident, $kernel_offsets:expr, $dist_offsets:expr $(,)?); )* } => {
         $(
             #[target_feature(enable = "avx2")]
             #[target_feature(enable = "fma")]
@@ -34,58 +34,71 @@ macro_rules! define_epf_avx2 {
                 let width = input[0].width();
                 let $width = width as isize;
                 let height = input[0].height();
-                assert_eq!(input[1].width(), width);
-                assert_eq!(input[2].width(), width);
-                assert_eq!(input[1].height(), height);
-                assert_eq!(input[2].height(), height);
-                assert_eq!(output[0].width(), width);
-                assert_eq!(output[1].width(), width);
-                assert_eq!(output[2].width(), width);
-                assert_eq!(output[0].height(), height);
-                assert_eq!(output[1].height(), height);
-                assert_eq!(output[2].height(), height);
+                assert!(width % 8 == 0);
 
                 let input_buf = [input[0].buf(), input[1].buf(), input[2].buf()];
                 let mut output_buf = {
                     let [a, b, c] = output;
                     [a.buf_mut(), b.buf_mut(), c.buf_mut()]
                 };
+                assert_eq!(input_buf[0].len(), width * height);
+                assert_eq!(input_buf[1].len(), width * height);
+                assert_eq!(input_buf[2].len(), width * height);
+                assert_eq!(output_buf[0].len(), width * height);
+                assert_eq!(output_buf[1].len(), width * height);
+                assert_eq!(output_buf[2].len(), width * height);
 
-                let sm_y_edge = Vector::splat_f32(border_sad_mul * step_multiplier);
-                let sm = Vector::set([
-                    border_sad_mul * step_multiplier, step_multiplier, step_multiplier, step_multiplier,
-                    step_multiplier, step_multiplier, step_multiplier, border_sad_mul * step_multiplier,
-                ]);
+                let height = height - 6;
 
-                for y in 3..height - 4 {
-                    let sigma_row = &sigma_grid.buf()[(y - 3) / 8 * sigma_grid.width()..][..(width + 1) / 8];
-                    for (vx, &sigma) in sigma_row.iter().enumerate() {
-                        let x = 3 + vx * 8;
-                        let idx_base = y * width + x;
+                for y in 0..height {
+                    let y8 = y / 8;
+                    let is_y_border = (y % 8) == 0 || (y % 8) == 7;
+                    let sm = if is_y_border {
+                        Vector::splat_f32(border_sad_mul * step_multiplier)
+                    } else {
+                        Vector::set([
+                            border_sad_mul * step_multiplier,
+                            step_multiplier,
+                            step_multiplier,
+                            step_multiplier,
+                            step_multiplier,
+                            step_multiplier,
+                            step_multiplier,
+                            border_sad_mul * step_multiplier,
+                        ])
+                    };
+
+                    for x8 in 1..width / 8 {
+                        let Some(&sigma) = sigma_grid.get(x8 - 1, y8) else { break; };
+
+                        let base_x = x8 * 8;
+                        let base_idx = (y + 3) * width + base_x;
 
                         // SAFETY: Indexing doesn't go out of bounds since we have padding after image region.
+                        // SAFETY: Every row is aligned to 32 bytes.
                         let mut sum_weights = Vector::splat_f32(1.0);
                         let mut sum_channels = input_buf.map(|buf| {
-                            Vector::load(buf.as_ptr().add(idx_base))
+                            Vector::load_aligned(buf.as_ptr().add(base_idx))
                         });
 
                         if sigma < 0.3 {
                             for (buf, sum) in output_buf.iter_mut().zip(sum_channels) {
-                                sum.store(buf.as_mut_ptr().add(idx_base));
+                                sum.store_aligned(buf.as_mut_ptr().add(base_idx));
                             }
                             continue;
                         }
 
-                        for kdiff in $kernel_diff {
-                            let kernel_base = idx_base.wrapping_add_signed(kdiff);
+                        for offset in $kernel_offsets {
+                            let kernel_idx = base_idx.wrapping_add_signed(offset);
                             let mut dist = Vector::zero();
                             for (buf, scale) in input_buf.into_iter().zip(channel_scale) {
                                 let scale = Vector::splat_f32(scale);
-                                for diff in $dist_diff {
-                                    dist = _mm256_fmadd_ps(
-                                        scale,
-                                        Vector::load(buf.as_ptr().add(idx_base.wrapping_add_signed(diff))).sub(
-                                            Vector::load(buf.as_ptr().add(kernel_base.wrapping_add_signed(diff)))
+                                for offset in $dist_offsets {
+                                    let base_idx = base_idx.wrapping_add_signed(offset);
+                                    let kernel_idx = kernel_idx.wrapping_add_signed(offset);
+                                    dist = scale.muladd(
+                                        Vector::load(buf.as_ptr().add(base_idx)).sub(
+                                            Vector::load(buf.as_ptr().add(kernel_idx))
                                         ).abs(),
                                         dist,
                                     );
@@ -95,26 +108,18 @@ macro_rules! define_epf_avx2 {
                             let weight = weight_avx2(
                                 dist,
                                 sigma,
-                                if (y - 3) % 8 == 0 || (y - 3) % 8 == 7 {
-                                    sm_y_edge
-                                } else {
-                                    sm
-                                },
+                                sm,
                             );
                             sum_weights = sum_weights.add(weight);
 
                             for (sum, buf) in sum_channels.iter_mut().zip(input_buf) {
-                                *sum = _mm256_fmadd_ps(
-                                    weight,
-                                    Vector::load(buf.as_ptr().add(kernel_base)),
-                                    *sum,
-                                );
+                                *sum = weight.muladd(Vector::load(buf.as_ptr().add(kernel_idx)), *sum);
                             }
                         }
 
                         for (buf, sum) in output_buf.iter_mut().zip(sum_channels) {
                             let val = sum.div(sum_weights);
-                            val.store(buf.as_mut_ptr().add(idx_base));
+                            val.store_aligned(buf.as_mut_ptr().add(base_idx));
                         }
                     }
                 }

--- a/crates/jxl-render/src/filter/impls/x86_64/epf_sse2.rs
+++ b/crates/jxl-render/src/filter/impls/x86_64/epf_sse2.rs
@@ -13,7 +13,7 @@ unsafe fn weight_sse2(scaled_distance: Vector, sigma: f32, step_multiplier: Vect
 }
 
 macro_rules! define_epf_sse2 {
-    { $($v:vis unsafe fn $name:ident ($width:ident, $kernel_diff:expr, $dist_diff:expr $(,)?); )* } => {
+    { $($v:vis unsafe fn $name:ident ($width:ident, $kernel_offsets:expr, $dist_offsets:expr $(,)?); )* } => {
         $(
             $v unsafe fn $name(
                 input: &[SimpleGrid<f32>; 3],
@@ -26,81 +26,88 @@ macro_rules! define_epf_sse2 {
                 let width = input[0].width();
                 let $width = width as isize;
                 let height = input[0].height();
-                assert_eq!(input[1].width(), width);
-                assert_eq!(input[2].width(), width);
-                assert_eq!(input[1].height(), height);
-                assert_eq!(input[2].height(), height);
-                assert_eq!(output[0].width(), width);
-                assert_eq!(output[1].width(), width);
-                assert_eq!(output[2].width(), width);
-                assert_eq!(output[0].height(), height);
-                assert_eq!(output[1].height(), height);
-                assert_eq!(output[2].height(), height);
+                assert!(width % 8 == 0);
 
                 let input_buf = [input[0].buf(), input[1].buf(), input[2].buf()];
                 let mut output_buf = {
                     let [a, b, c] = output;
                     [a.buf_mut(), b.buf_mut(), c.buf_mut()]
                 };
+                assert_eq!(input_buf[0].len(), width * height);
+                assert_eq!(input_buf[1].len(), width * height);
+                assert_eq!(input_buf[2].len(), width * height);
+                assert_eq!(output_buf[0].len(), width * height);
+                assert_eq!(output_buf[1].len(), width * height);
+                assert_eq!(output_buf[2].len(), width * height);
 
-                let sm_y_edge = Vector::splat_f32(border_sad_mul * step_multiplier);
-                let sm_left = Vector::set([border_sad_mul * step_multiplier, step_multiplier, step_multiplier, step_multiplier]);
-                let sm_right = Vector::set([step_multiplier, step_multiplier, step_multiplier, border_sad_mul * step_multiplier]);
+                let height = height - 6;
 
-                for y in 3..height - 4 {
-                    for x in (3..width - 3).step_by(Vector::SIZE) {
-                        let sigma = *sigma_grid.get((x - 3) / 8, (y - 3) / 8).unwrap();
-                        let idx_base = y * width + x;
+                for y in 0..height {
+                    let y8 = y / 8;
+                    let is_y_border = (y % 8) == 0 || (y % 8) == 7;
+                    let sm = if is_y_border {
+                        let sm_y_edge = Vector::splat_f32(border_sad_mul * step_multiplier);
+                        [sm_y_edge, sm_y_edge]
+                    } else {
+                        let sm_left = Vector::set([border_sad_mul * step_multiplier, step_multiplier, step_multiplier, step_multiplier]);
+                        let sm_right = Vector::set([step_multiplier, step_multiplier, step_multiplier, border_sad_mul * step_multiplier]);
+                        [sm_left, sm_right]
+                    };
 
-                        // SAFETY: Indexing doesn't go out of bounds since we have padding after image region.
-                        let mut sum_weights = Vector::splat_f32(1.0);
-                        let mut sum_channels = input_buf.map(|buf| {
-                            Vector::load(buf.as_ptr().add(idx_base))
-                        });
+                    for x8 in 1..width / 8 {
+                        let Some(&sigma) = sigma_grid.get(x8 - 1, y8) else { break; };
 
-                        if sigma < 0.3 {
-                            for (buf, sum) in output_buf.iter_mut().zip(sum_channels) {
-                                sum.store(buf.as_mut_ptr().add(idx_base));
+                        for (dx, sm) in sm.into_iter().enumerate() {
+                            let base_x = x8 * 8 + dx * Vector::SIZE;
+                            let base_idx = (y + 3) * width + base_x;
+
+                            // SAFETY: Indexing doesn't go out of bounds since we have padding after image region.
+                            // SAFETY: Every row is aligned to 32 bytes.
+                            let mut sum_weights = Vector::splat_f32(1.0);
+                            let mut sum_channels = input_buf.map(|buf| {
+                                Vector::load_aligned(buf.as_ptr().add(base_idx))
+                            });
+
+                            if sigma < 0.3 {
+                                for (buf, sum) in output_buf.iter_mut().zip(sum_channels) {
+                                    sum.store_aligned(buf.as_mut_ptr().add(base_idx));
+                                }
+                                continue;
                             }
-                            continue;
-                        }
 
-                        for kdiff in $kernel_diff {
-                            let kernel_base = idx_base.wrapping_add_signed(kdiff);
-                            let mut dist = Vector::zero();
-                            for (buf, scale) in input_buf.into_iter().zip(channel_scale) {
-                                let scale = Vector::splat_f32(scale);
-                                for diff in $dist_diff {
-                                    dist = scale.muladd(
-                                        Vector::load(buf.as_ptr().add(idx_base.wrapping_add_signed(diff))).sub(
-                                            Vector::load(buf.as_ptr().add(kernel_base.wrapping_add_signed(diff)))
-                                        ).abs(),
-                                        dist,
-                                    );
+                            for offset in $kernel_offsets {
+                                let kernel_idx = base_idx.wrapping_add_signed(offset);
+                                let mut dist = Vector::zero();
+                                for (buf, scale) in input_buf.into_iter().zip(channel_scale) {
+                                    let scale = Vector::splat_f32(scale);
+                                    for offset in $dist_offsets {
+                                        let base_idx = base_idx.wrapping_add_signed(offset);
+                                        let kernel_idx = kernel_idx.wrapping_add_signed(offset);
+                                        dist = scale.muladd(
+                                            Vector::load(buf.as_ptr().add(base_idx)).sub(
+                                                Vector::load(buf.as_ptr().add(kernel_idx))
+                                            ).abs(),
+                                            dist,
+                                        );
+                                    }
+                                }
+
+                                let weight = weight_sse2(
+                                    dist,
+                                    sigma,
+                                    sm,
+                                );
+                                sum_weights = sum_weights.add(weight);
+
+                                for (sum, buf) in sum_channels.iter_mut().zip(input_buf) {
+                                    *sum = weight.muladd(Vector::load(buf.as_ptr().add(kernel_idx)), *sum);
                                 }
                             }
 
-                            let weight = weight_sse2(
-                                dist,
-                                sigma,
-                                if (y - 3) % 8 == 0 || (y - 3) % 8 == 7 {
-                                    sm_y_edge
-                                } else if (x - 3) % 8 == 0 {
-                                    sm_left
-                                } else {
-                                    sm_right
-                                },
-                            );
-                            sum_weights = sum_weights.add(weight);
-
-                            for (sum, buf) in sum_channels.iter_mut().zip(input_buf) {
-                                *sum = weight.muladd(Vector::load(buf.as_ptr().add(kernel_base)), *sum);
+                            for (buf, sum) in output_buf.iter_mut().zip(sum_channels) {
+                                let val = sum.div(sum_weights);
+                                val.store_aligned(buf.as_mut_ptr().add(base_idx));
                             }
-                        }
-
-                        for (buf, sum) in output_buf.iter_mut().zip(sum_channels) {
-                            let val = sum.div(sum_weights);
-                            val.store(buf.as_mut_ptr().add(idx_base));
                         }
                     }
                 }


### PR DESCRIPTION
cc #80 

Adjusts mirror padding so that the grid width becomes multiple of 8. Also fixes mirror operation with grid width less than 3.