### PR TITLE
jxl-render: NEON version of EPF

### DIFF
--- a/crates/jxl-grid/src/simd.rs
+++ b/crates/jxl-grid/src/simd.rs
@@ -322,3 +322,89 @@ impl SimdVector for std::arch::x86_64::__m256 {
         self.mul(mul).sub(sub)
     }
 }
+
+#[cfg(target_arch = "aarch64")]
+impl SimdVector for std::arch::aarch64::float32x4_t {
+    const SIZE: usize = 4;
+
+    #[inline]
+    fn available() -> bool {
+        std::arch::is_aarch64_feature_detected!("neon")
+    }
+
+    #[inline]
+    unsafe fn zero() -> Self {
+        std::arch::aarch64::vdupq_n_f32(0f32)
+    }
+
+    #[inline]
+    unsafe fn set<const N: usize>(val: [f32; N]) -> Self {
+        assert_eq!(N, Self::SIZE);
+        std::arch::aarch64::vld1q_f32(val.as_ptr())
+    }
+
+    #[inline]
+    unsafe fn splat_f32(val: f32) -> Self {
+        std::arch::aarch64::vdupq_n_f32(val)
+    }
+
+    #[inline]
+    unsafe fn load(ptr: *const f32) -> Self {
+        std::arch::aarch64::vld1q_f32(ptr)
+    }
+
+    #[inline]
+    unsafe fn load_aligned(ptr: *const f32) -> Self {
+        std::arch::aarch64::vld1q_f32(ptr)
+    }
+
+    #[inline]
+    unsafe fn extract_f32<const N: i32>(self) -> f32 {
+        std::arch::aarch64::vgetq_lane_f32::<N>(self)
+    }
+
+    #[inline]
+    unsafe fn store(self, ptr: *mut f32) {
+        std::arch::aarch64::vst1q_f32(ptr, self)
+    }
+
+    #[inline]
+    unsafe fn store_aligned(self, ptr: *mut f32) {
+        std::arch::aarch64::vst1q_f32(ptr, self)
+    }
+
+    #[inline]
+    unsafe fn add(self, lhs: Self) -> Self {
+        std::arch::aarch64::vaddq_f32(self, lhs)
+    }
+
+    #[inline]
+    unsafe fn sub(self, lhs: Self) -> Self {
+        std::arch::aarch64::vsubq_f32(self, lhs)
+    }
+
+    #[inline]
+    unsafe fn mul(self, lhs: Self) -> Self {
+        std::arch::aarch64::vmulq_f32(self, lhs)
+    }
+
+    #[inline]
+    unsafe fn div(self, lhs: Self) -> Self {
+        std::arch::aarch64::vdivq_f32(self, lhs)
+    }
+
+    #[inline]
+    unsafe fn abs(self) -> Self {
+        std::arch::aarch64::vabsq_f32(self)
+    }
+
+    #[inline]
+    unsafe fn muladd(self, mul: Self, add: Self) -> Self {
+        std::arch::aarch64::vfmaq_f32(add, self, mul)
+    }
+
+    #[inline]
+    unsafe fn mulsub(self, mul: Self, sub: Self) -> Self {
+        std::arch::aarch64::vfmsq_f32(sub, self, mul)
+    }
+}

--- a/crates/jxl-render/src/filter/impls.rs
+++ b/crates/jxl-render/src/filter/impls.rs
@@ -1,13 +1,17 @@
-#[cfg(not(target_arch = "x86_64"))]
 mod generic;
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
+#[cfg(target_arch = "aarch64")]
+mod aarch64;
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub use generic::*;
 
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::*;
+
+#[cfg(target_arch = "aarch64")]
+pub use aarch64::*;
 
 #[inline(always)]
 fn run_gabor_inner(fb: &mut jxl_grid::SimpleGrid<f32>, weight1: f32, weight2: f32) {

--- a/crates/jxl-render/src/filter/impls/aarch64.rs
+++ b/crates/jxl-render/src/filter/impls/aarch64.rs
@@ -1,0 +1,103 @@
+use std::arch::is_aarch64_feature_detected;
+
+use jxl_grid::SimpleGrid;
+
+mod epf;
+
+pub use super::generic::apply_gabor_like;
+
+pub fn epf_step0(
+    input: &[SimpleGrid<f32>; 3],
+    output: &mut [SimpleGrid<f32>; 3],
+    sigma_grid: &SimpleGrid<f32>,
+    channel_scale: [f32; 3],
+    border_sad_mul: f32,
+    step_multiplier: f32,
+) {
+    if is_aarch64_feature_detected!("neon") {
+        // SAFETY: Features are checked above.
+        unsafe {
+            return epf::epf_step0_neon(
+                input,
+                output,
+                sigma_grid,
+                channel_scale,
+                border_sad_mul,
+                step_multiplier,
+            );
+        }
+    }
+
+    super::generic::epf_step0(
+        input,
+        output,
+        sigma_grid,
+        channel_scale,
+        border_sad_mul,
+        step_multiplier,
+    )
+}
+
+pub fn epf_step1(
+    input: &[SimpleGrid<f32>; 3],
+    output: &mut [SimpleGrid<f32>; 3],
+    sigma_grid: &SimpleGrid<f32>,
+    channel_scale: [f32; 3],
+    border_sad_mul: f32,
+    step_multiplier: f32,
+) {
+    if is_aarch64_feature_detected!("neon") {
+        // SAFETY: Features are checked above.
+        unsafe {
+            return epf::epf_step1_neon(
+                input,
+                output,
+                sigma_grid,
+                channel_scale,
+                border_sad_mul,
+                step_multiplier,
+            );
+        }
+    }
+
+    super::generic::epf_step1(
+        input,
+        output,
+        sigma_grid,
+        channel_scale,
+        border_sad_mul,
+        step_multiplier,
+    )
+}
+
+pub fn epf_step2(
+    input: &[SimpleGrid<f32>; 3],
+    output: &mut [SimpleGrid<f32>; 3],
+    sigma_grid: &SimpleGrid<f32>,
+    channel_scale: [f32; 3],
+    border_sad_mul: f32,
+    step_multiplier: f32,
+) {
+    if is_aarch64_feature_detected!("neon") {
+        // SAFETY: Features are checked above.
+        unsafe {
+            return epf::epf_step2_neon(
+                input,
+                output,
+                sigma_grid,
+                channel_scale,
+                border_sad_mul,
+                step_multiplier,
+            );
+        }
+    }
+
+    super::generic::epf_step2(
+        input,
+        output,
+        sigma_grid,
+        channel_scale,
+        border_sad_mul,
+        step_multiplier,
+    )
+}

--- a/crates/jxl-render/src/filter/impls/aarch64/epf.rs
+++ b/crates/jxl-render/src/filter/impls/aarch64/epf.rs
@@ -1,0 +1,150 @@
+use std::arch::aarch64::*;
+
+use jxl_grid::SimpleGrid;
+use jxl_grid::SimdVector;
+
+type Vector = float32x4_t;
+
+#[target_feature(enable = "neon")]
+#[inline]
+unsafe fn weight_neon(scaled_distance: Vector, sigma: f32, step_multiplier: Vector) -> Vector {
+    let result = vfmaq_n_f32(
+        Vector::splat_f32(1.0),
+        scaled_distance.mul(step_multiplier),
+        6.6 * (std::f32::consts::FRAC_1_SQRT_2 - 1.0) / sigma,
+    );
+    vmaxq_f32(result, Vector::zero())
+}
+
+macro_rules! define_epf_neon {
+    { $($v:vis unsafe fn $name:ident ($width:ident, $kernel_offsets:expr, $dist_offsets:expr $(,)?); )* } => {
+        $(
+            #[target_feature(enable = "neon")]
+            $v unsafe fn $name(
+                input: &[SimpleGrid<f32>; 3],
+                output: &mut [SimpleGrid<f32>; 3],
+                sigma_grid: &SimpleGrid<f32>,
+                channel_scale: [f32; 3],
+                border_sad_mul: f32,
+                step_multiplier: f32,
+            ) {
+                let width = input[0].width();
+                let $width = width as isize;
+                let height = input[0].height();
+                assert!(width % 8 == 0);
+
+                let input_buf = [input[0].buf(), input[1].buf(), input[2].buf()];
+                let mut output_buf = {
+                    let [a, b, c] = output;
+                    [a.buf_mut(), b.buf_mut(), c.buf_mut()]
+                };
+                assert_eq!(input_buf[0].len(), width * height);
+                assert_eq!(input_buf[1].len(), width * height);
+                assert_eq!(input_buf[2].len(), width * height);
+                assert_eq!(output_buf[0].len(), width * height);
+                assert_eq!(output_buf[1].len(), width * height);
+                assert_eq!(output_buf[2].len(), width * height);
+
+                let height = height - 6;
+
+                for y in 0..height {
+                    let y8 = y / 8;
+                    let is_y_border = (y % 8) == 0 || (y % 8) == 7;
+                    let sm = if is_y_border {
+                        let sm_y_edge = Vector::splat_f32(border_sad_mul * step_multiplier);
+                        [sm_y_edge, sm_y_edge]
+                    } else {
+                        let sm = Vector::splat_f32(step_multiplier);
+                        [
+                            vsetq_lane_f32(border_sad_mul * step_multiplier, sm, 0),
+                            vsetq_lane_f32(border_sad_mul * step_multiplier, sm, 3),
+                        ]
+                    };
+
+                    for x8 in 1..width / 8 {
+                        let Some(&sigma) = sigma_grid.get(x8 - 1, y8) else { break; };
+
+                        for (dx, sm) in sm.into_iter().enumerate() {
+                            let base_x = x8 * 8 + dx * Vector::SIZE;
+                            let base_idx = (y + 3) * width + base_x;
+
+                            // SAFETY: Indexing doesn't go out of bounds since we have padding after image region.
+                            let mut sum_weights = Vector::splat_f32(1.0);
+                            let mut sum_channels = input_buf.map(|buf| {
+                                Vector::load(buf.as_ptr().add(base_idx))
+                            });
+
+                            if sigma < 0.3 {
+                                for (buf, sum) in output_buf.iter_mut().zip(sum_channels) {
+                                    sum.store(buf.as_mut_ptr().add(base_idx));
+                                }
+                                continue;
+                            }
+
+                            for offset in $kernel_offsets {
+                                let kernel_idx = base_idx.wrapping_add_signed(offset);
+                                let mut dist = Vector::zero();
+                                for (buf, scale) in input_buf.into_iter().zip(channel_scale) {
+                                    let mut acc = Vector::zero();
+                                    for offset in $dist_offsets {
+                                        let base_idx = base_idx.wrapping_add_signed(offset);
+                                        let kernel_idx = kernel_idx.wrapping_add_signed(offset);
+                                        acc = acc.add(vabdq_f32(
+                                            Vector::load(buf.as_ptr().add(base_idx)),
+                                            Vector::load(buf.as_ptr().add(kernel_idx)),
+                                        ));
+                                    }
+                                    dist = vfmaq_n_f32(
+                                        dist,
+                                        acc,
+                                        scale,
+                                    );
+                                }
+
+                                let weight = weight_neon(
+                                    dist,
+                                    sigma,
+                                    sm,
+                                );
+                                sum_weights = sum_weights.add(weight);
+
+                                for (sum, buf) in sum_channels.iter_mut().zip(input_buf) {
+                                    *sum = weight.muladd(Vector::load(buf.as_ptr().add(kernel_idx)), *sum);
+                                }
+                            }
+
+                            for (buf, sum) in output_buf.iter_mut().zip(sum_channels) {
+                                let val = sum.div(sum_weights);
+                                val.store(buf.as_mut_ptr().add(base_idx));
+                            }
+                        }
+                    }
+                }
+            }
+        )*
+    };
+}
+
+define_epf_neon! {
+    pub unsafe fn epf_step0_neon(
+        width,
+        [
+            -2 * width,
+            -1 - width, -width, 1 - width,
+            -2, -1, 1, 2,
+            width - 1, width, width + 1,
+            2 * width,
+        ],
+        [-width, -1, 0, 1, width],
+    );
+    pub unsafe fn epf_step1_neon(
+        width,
+        [-width, -1, 1, width],
+        [-width, -1, 0, 1, width],
+    );
+    pub unsafe fn epf_step2_neon(
+        width,
+        [-width, -1, 1, width],
+        [0isize],
+    );
+}

--- a/crates/jxl-render/src/filter/impls/generic.rs
+++ b/crates/jxl-render/src/filter/impls/generic.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use jxl_grid::SimpleGrid;
 
 #[inline]

--- a/crates/jxl-render/src/filter/impls/generic.rs
+++ b/crates/jxl-render/src/filter/impls/generic.rs
@@ -71,7 +71,7 @@ macro_rules! define_epf {
                                     for offset in $dist_offsets {
                                         let base_idx = base_idx.wrapping_add_signed(offset);
                                         let kernel_idx = kernel_idx.wrapping_add_signed(offset);
-                                        dist += (ch[base_idx] - ch[kernel_idx]).abs() * scale;
+                                        dist = scale.mul_add((ch[base_idx] - ch[kernel_idx]).abs(), dist);
                                     }
                                 }
 
@@ -84,7 +84,7 @@ macro_rules! define_epf {
 
                                 for (sum, ch) in sum_channels.iter_mut().zip(input) {
                                     let ch = ch.buf();
-                                    *sum += ch[kernel_idx] * weight;
+                                    *sum = weight.mul_add(ch[kernel_idx], *sum);
                                 }
                             }
 


### PR DESCRIPTION
On my M1 Max machine, decoding performance of jxl-oxide is on par with single-threaded libjxl, and it's even faster than libjxl for some images.