### PR TITLE
jxl-info: Print offsets of frame groups

### DIFF
--- a/crates/jxl-frame/src/data/toc.rs
+++ b/crates/jxl-frame/src/data/toc.rs
@@ -139,6 +139,20 @@ impl Toc {
     }
 }
 
+impl Toc {
+    pub(crate) fn adjust_offsets(&mut self, global_frame_offset: usize) {
+        if global_frame_offset == 0 {
+            return;
+        }
+
+        for group in &mut self.groups {
+            group.offset = group.offset
+                .checked_sub(global_frame_offset)
+                .expect("group offset is smaller than global frame offset");
+        }
+    }
+}
+
 impl Bundle<&crate::FrameHeader> for Toc {
     type Error = crate::Error;
 

--- a/crates/jxl-frame/src/data/toc.rs
+++ b/crates/jxl-frame/src/data/toc.rs
@@ -15,7 +15,7 @@ pub struct Toc {
     groups: Vec<TocGroup>,
     bitstream_to_original: Vec<usize>,
     original_to_bitstream: Vec<usize>,
-    total_size: u64,
+    total_size: usize,
 }
 
 impl std::fmt::Debug for Toc {
@@ -50,7 +50,7 @@ pub struct TocGroup {
     /// Kind of the group.
     pub kind: TocGroupKind,
     /// Offset within the bitstream.
-    pub offset: u64,
+    pub offset: usize,
     /// Size of the group.
     pub size: u32,
 }
@@ -95,7 +95,7 @@ impl PartialOrd for TocGroupKind {
 
 impl Toc {
     /// Returns the offset to the beginning of the data.
-    pub fn bookmark(&self) -> u64 {
+    pub fn bookmark(&self) -> usize {
         let idx = self.bitstream_to_original.first().copied().unwrap_or(0);
         self.groups[idx].offset
     }
@@ -125,7 +125,7 @@ impl Toc {
     }
 
     /// Returns the total size of the frame data in bytes.
-    pub fn total_byte_size(&self) -> u64 {
+    pub fn total_byte_size(&self) -> usize {
         self.total_size
     }
 
@@ -176,12 +176,12 @@ impl Bundle<&crate::FrameHeader> for Toc {
         bitstream.zero_pad_to_byte()?;
 
         let mut offsets = Vec::with_capacity(sizes.len());
-        let mut acc = bitstream.num_read_bits() as u64;
-        let mut total_size = 0u64;
+        let mut acc = bitstream.num_read_bits() / 8;
+        let mut total_size = 0usize;
         for &size in &sizes {
             offsets.push(acc);
-            acc += size as u64 * 8;
-            total_size += size as u64;
+            acc += size as usize;
+            total_size += size as usize;
         }
 
         let section_kinds = if entry_count == 1 {

--- a/crates/jxl-frame/src/data/toc.rs
+++ b/crates/jxl-frame/src/data/toc.rs
@@ -49,7 +49,7 @@ impl std::fmt::Debug for Toc {
 pub struct TocGroup {
     /// Kind of the group.
     pub kind: TocGroupKind,
-    /// Offset within the bitstream.
+    /// Offset from the beginning of frame header.
     pub offset: usize,
     /// Size of the group.
     pub size: u32,

--- a/crates/jxl-oxide/src/lib.rs
+++ b/crates/jxl-oxide/src/lib.rs
@@ -103,7 +103,7 @@ use jxl_bitstream::Name;
 pub use jxl_frame::{Frame, FrameHeader};
 pub use jxl_grid::SimpleGrid;
 pub use jxl_image::{ExtraChannelType, ImageHeader};
-use jxl_render::RenderContext;
+use jxl_render::{RenderContext, IndexedFrame};
 
 pub use fb::FrameBuffer;
 
@@ -150,6 +150,10 @@ impl UninitializedJxlImage {
         self.reader.feed_bytes(buf)?;
         self.buffer.extend(self.reader.take_bytes());
         Ok(())
+    }
+
+    pub fn reader(&self) -> &ContainerDetectingReader {
+        &self.reader
     }
 
     /// Try to initialize an image with the data fed into so far.
@@ -202,7 +206,7 @@ impl UninitializedJxlImage {
             };
 
             let bytes_read = bitstream.num_read_bits() / 8;
-            let x = frame.toc().total_byte_size() as usize;
+            let x = frame.toc().total_byte_size();
             if self.buffer.len() < bytes_read + x {
                 return Ok(InitializeResult::NeedMoreData(self));
             }
@@ -225,6 +229,8 @@ impl UninitializedJxlImage {
             render_spot_colour,
             end_of_image: false,
             buffer: Vec::new(),
+            buffer_offset: bytes_read,
+            frame_offsets: Vec::new(),
         };
         image.feed_bytes_inner(&self.buffer)?;
 
@@ -250,6 +256,8 @@ pub struct JxlImage {
     render_spot_colour: bool,
     end_of_image: bool,
     buffer: Vec<u8>,
+    buffer_offset: usize,
+    frame_offsets: Vec<usize>,
 }
 
 impl JxlImage {
@@ -417,7 +425,11 @@ impl JxlImage {
 
         if let Some(loading_frame) = self.ctx.current_loading_frame() {
             debug_assert!(self.buffer.is_empty());
+            let len = buf.len();
             buf = loading_frame.feed_bytes(buf);
+            let count = len - buf.len();
+            self.buffer_offset += count;
+
             if loading_frame.is_loading_done() {
                 let is_last = loading_frame.header().is_last;
                 self.ctx.finalize_current_frame();
@@ -446,9 +458,16 @@ impl JxlImage {
                     return Err(e.into());
                 },
             };
+            let frame_index = frame.index();
+            assert_eq!(self.frame_offsets.len(), frame_index);
+            self.frame_offsets.push(self.buffer_offset);
+
             let read_bytes = bitstream.num_read_bits() / 8;
             buf = &buf[read_bytes..];
+            let len = buf.len();
             buf = frame.feed_bytes(buf);
+            let read_bytes = read_bytes + (len - buf.len());
+            self.buffer_offset += read_bytes;
 
             if frame.is_loading_done() {
                 let is_last = frame.header().is_last;
@@ -467,6 +486,7 @@ impl JxlImage {
 
     pub fn try_take_buffer(&mut self) -> Option<Vec<u8>> {
         if self.end_of_image {
+            self.buffer_offset += self.buffer.len();
             Some(std::mem::take(&mut self.buffer))
         } else {
             None
@@ -495,9 +515,25 @@ impl JxlImage {
         Some(frame.header())
     }
 
+    pub fn frame_by_keyframe(&self, keyframe_index: usize) -> Option<&IndexedFrame> {
+        self.ctx.keyframe(keyframe_index)
+    }
+
+    pub fn frame(&self, frame_idx: usize) -> Option<&IndexedFrame> {
+        self.ctx.frame(frame_idx)
+    }
+
+    pub fn frame_offset(&self, frame_index: usize) -> Option<usize> {
+        self.frame_offsets.get(frame_index).copied()
+    }
+
     /// Returns the number of currently loaded keyframes.
     pub fn num_loaded_keyframes(&self) -> usize {
         self.ctx.loaded_keyframes()
+    }
+
+    pub fn num_loaded_frames(&self) -> usize {
+        self.ctx.loaded_frames()
     }
 
     /// Renders the given keyframe with optional cropping region.

--- a/crates/jxl-oxide/src/lib.rs
+++ b/crates/jxl-oxide/src/lib.rs
@@ -515,14 +515,17 @@ impl JxlImage {
         Some(frame.header())
     }
 
+    /// Returns frame data by keyframe index.
     pub fn frame_by_keyframe(&self, keyframe_index: usize) -> Option<&IndexedFrame> {
         self.ctx.keyframe(keyframe_index)
     }
 
+    /// Returns frame data by frame index, including frames that are not displayed directly.
     pub fn frame(&self, frame_idx: usize) -> Option<&IndexedFrame> {
         self.ctx.frame(frame_idx)
     }
 
+    /// Returns the offset of frame within codestream, in bytes.
     pub fn frame_offset(&self, frame_index: usize) -> Option<usize> {
         self.frame_offsets.get(frame_index).copied()
     }
@@ -532,6 +535,8 @@ impl JxlImage {
         self.ctx.loaded_keyframes()
     }
 
+    /// Returns the number of currently loaded frames, including frames that are not displayed
+    /// directly.
     pub fn num_loaded_frames(&self) -> usize {
         self.ctx.loaded_frames()
     }

--- a/crates/jxl-render/src/lib.rs
+++ b/crates/jxl-render/src/lib.rs
@@ -58,6 +58,11 @@ impl RenderContext {
     pub fn loaded_keyframes(&self) -> usize {
         self.inner.loaded_keyframes()
     }
+
+    #[inline]
+    pub fn loaded_frames(&self) -> usize {
+        self.inner.frames.len()
+    }
 }
 
 impl RenderContext {
@@ -101,6 +106,15 @@ impl RenderContext {
     #[inline]
     pub fn keyframe(&self, keyframe_idx: usize) -> Option<&IndexedFrame> {
         self.inner.keyframe(keyframe_idx)
+    }
+
+    #[inline]
+    pub fn frame(&self, frame_idx: usize) -> Option<&IndexedFrame> {
+        if self.inner.frames.len() == frame_idx {
+            self.inner.loading_frame.as_ref()
+        } else {
+            self.inner.frames.get(frame_idx)
+        }
     }
 }
 


### PR DESCRIPTION
Use `--with-offset` to print frame offset and group size information:

<details>

```
JPEG XL image (BareCodestream)
  Image dimension: 800x600
  Bit depth: 8 bits
  XYB encoded, suggested display color encoding:
    Colorspace: RGB
    White point: D65
    Primaries: sRGB
    Transfer function: sRGB
Frame #0 (keyframe)
  VarDCT (lossy)
  Frame type: Regular
  800x600; (0, 0)
  Offset (in codestream): 9 (0x9)
  Frame header size: 31 (0x1f) bytes
  Group sizes, in bitstream order:
    LfGlobal: 11168 (0x2ba0) bytes
    LfGroup(0): 8525 (0x214d) bytes
    HfGlobal: 868 (0x364) bytes
    GroupPass { pass_idx: 0, group_idx: 0 }: 3889 (0xf31) bytes
    GroupPass { pass_idx: 0, group_idx: 1 }: 8053 (0x1f75) bytes
    GroupPass { pass_idx: 0, group_idx: 2 }: 4086 (0xff6) bytes
    GroupPass { pass_idx: 0, group_idx: 3 }: 13 (0xd) bytes
    GroupPass { pass_idx: 0, group_idx: 4 }: 365 (0x16d) bytes
    GroupPass { pass_idx: 0, group_idx: 5 }: 7774 (0x1e5e) bytes
    GroupPass { pass_idx: 0, group_idx: 6 }: 1376 (0x560) bytes
    GroupPass { pass_idx: 0, group_idx: 7 }: 13 (0xd) bytes
    GroupPass { pass_idx: 0, group_idx: 8 }: 115 (0x73) bytes
    GroupPass { pass_idx: 0, group_idx: 9 }: 472 (0x1d8) bytes
    GroupPass { pass_idx: 0, group_idx: 10 }: 127 (0x7f) bytes
    GroupPass { pass_idx: 0, group_idx: 11 }: 9 (0x9) bytes
```

</details>

Use `--all-frames` to show invisible frames:

<details>

```
JPEG XL image (BareCodestream)
  Image dimension: 4064x2704
  Bit depth: 8 bits
  XYB encoded, suggested display color encoding:
    Embedded ICC profile (896 bytes)
Frame #0
  Modular (maybe lossless)
  Frame type: Reference only, slot 0
  29x28
Frame #1
  Modular (maybe lossless)
  Frame type: LF, level 1 (8x downsampled)
  508x338
Frame #2 (keyframe)
  VarDCT (lossy)
  Frame type: Regular
  4064x2704; (0, 0)
```

</details>