### PR TITLE
Add license symlinks to individual crates

### DIFF
--- a/crates/jxl-bitstream/LICENSE-APACHE
+++ b/crates/jxl-bitstream/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/jxl-bitstream/LICENSE-MIT
+++ b/crates/jxl-bitstream/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/jxl-coding/LICENSE-APACHE
+++ b/crates/jxl-coding/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/jxl-coding/LICENSE-MIT
+++ b/crates/jxl-coding/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/jxl-color/LICENSE-APACHE
+++ b/crates/jxl-color/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/jxl-color/LICENSE-MIT
+++ b/crates/jxl-color/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/jxl-frame/LICENSE-APACHE
+++ b/crates/jxl-frame/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/jxl-frame/LICENSE-MIT
+++ b/crates/jxl-frame/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/jxl-grid/LICENSE-APACHE
+++ b/crates/jxl-grid/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/jxl-grid/LICENSE-MIT
+++ b/crates/jxl-grid/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/jxl-image/LICENSE-APACHE
+++ b/crates/jxl-image/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/jxl-image/LICENSE-MIT
+++ b/crates/jxl-image/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/jxl-modular/LICENSE-APACHE
+++ b/crates/jxl-modular/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/jxl-modular/LICENSE-MIT
+++ b/crates/jxl-modular/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/jxl-oxide-cli/LICENSE-APACHE
+++ b/crates/jxl-oxide-cli/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/jxl-oxide-cli/LICENSE-MIT
+++ b/crates/jxl-oxide-cli/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/jxl-oxide-fuzz/LICENSE-APACHE
+++ b/crates/jxl-oxide-fuzz/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/jxl-oxide-fuzz/LICENSE-MIT
+++ b/crates/jxl-oxide-fuzz/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/jxl-oxide/LICENSE-APACHE
+++ b/crates/jxl-oxide/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/jxl-oxide/LICENSE-MIT
+++ b/crates/jxl-oxide/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/jxl-render/LICENSE-APACHE
+++ b/crates/jxl-render/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/jxl-render/LICENSE-MIT
+++ b/crates/jxl-render/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/jxl-vardct/LICENSE-APACHE
+++ b/crates/jxl-vardct/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/jxl-vardct/LICENSE-MIT
+++ b/crates/jxl-vardct/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT


### PR DESCRIPTION
This ensures that the license files get included in individual crates that are uploaded to crates.io.