### PR TITLE
jxl-color: Implement tone mapping

### DIFF
--- a/crates/jxl-color/src/convert.rs
+++ b/crates/jxl-color/src/convert.rs
@@ -678,7 +678,10 @@ impl ColorTransformOp {
                 }
                 3
             }
-            Self::GamutMap { luminances, saturation_factor } => {
+            Self::GamutMap {
+                luminances,
+                saturation_factor,
+            } => {
                 let [r, g, b, ..] = channels else {
                     unreachable!()
                 };

--- a/crates/jxl-color/src/convert/tone_map.rs
+++ b/crates/jxl-color/src/convert/tone_map.rs
@@ -1,0 +1,132 @@
+use super::HdrParams;
+
+pub(super) fn tone_map(
+    r: &mut [f32],
+    g: &mut [f32],
+    b: &mut [f32],
+    hdr_params: &HdrParams,
+    target_display_luminance: f32,
+) {
+    assert_eq!(r.len(), g.len());
+    assert_eq!(g.len(), b.len());
+
+    let luminances = hdr_params.luminances;
+    let intensity_target = hdr_params.intensity_target;
+    let min_nits = hdr_params.min_nits;
+    let detected_peak_luminance = detect_peak_luminance(r, g, b, luminances) * intensity_target;
+    let peak_luminance = intensity_target.min(detected_peak_luminance);
+
+    tone_map_generic(
+        r,
+        g,
+        b,
+        luminances,
+        intensity_target,
+        (min_nits, peak_luminance),
+        (0.0, target_display_luminance),
+    );
+}
+
+fn tone_map_generic(
+    r: &mut [f32],
+    g: &mut [f32],
+    b: &mut [f32],
+    luminances: [f32; 3],
+    intensity_target: f32,
+    from_luminance_range: (f32, f32),
+    to_luminance_range: (f32, f32),
+) {
+    assert_eq!(r.len(), g.len());
+    assert_eq!(g.len(), b.len());
+    let scale = intensity_target / to_luminance_range.1;
+
+    let [lr, lg, lb] = luminances;
+    for ((r, g), b) in r.iter_mut().zip(g).zip(b) {
+        let y = *r * lr + *g * lg + *b * lb;
+        let mut y_pq = y;
+        crate::tf::linear_to_pq(std::slice::from_mut(&mut y_pq), intensity_target);
+        let mut y_mapped = crate::tf::rec2408_eetf_generic(
+            y_pq,
+            intensity_target,
+            from_luminance_range,
+            to_luminance_range,
+        );
+        crate::tf::pq_to_linear(std::slice::from_mut(&mut y_mapped), intensity_target);
+        let ratio = y_mapped / y * scale;
+        *r *= ratio;
+        *g *= ratio;
+        *b *= ratio;
+    }
+}
+
+fn detect_peak_luminance(
+    r: &[f32],
+    g: &[f32],
+    b: &[f32],
+    luminances: [f32; 3],
+) -> f32 {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if std::arch::is_x86_feature_detected!("avx2") {
+            unsafe {
+                return detect_peak_luminance_avx2(r, g, b, luminances);
+            }
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        if std::arch::is_aarch64_feature_detected!("neon") {
+            unsafe {
+                return detect_peak_luminance_neon(r, g, b, luminances);
+            }
+        }
+    }
+
+    detect_peak_luminance_impl(r, g, b, luminances)
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn detect_peak_luminance_avx2(
+    r: &[f32],
+    g: &[f32],
+    b: &[f32],
+    luminances: [f32; 3],
+) -> f32 {
+    detect_peak_luminance_impl(r, g, b, luminances)
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn detect_peak_luminance_neon(
+    r: &[f32],
+    g: &[f32],
+    b: &[f32],
+    luminances: [f32; 3],
+) -> f32 {
+    detect_peak_luminance_impl(r, g, b, luminances)
+}
+
+fn detect_peak_luminance_impl(
+    r: &[f32],
+    g: &[f32],
+    b: &[f32],
+    luminances: [f32; 3],
+) -> f32 {
+    assert_eq!(r.len(), g.len());
+    assert_eq!(g.len(), b.len());
+
+    let [lr, lg, lb] = luminances;
+    let mut peak_luminance = 0f32;
+    for ((r, g), b) in r.iter().zip(g).zip(b) {
+        let y = r * lr + g * lg + b * lb;
+        peak_luminance = peak_luminance.max(y);
+    }
+
+    if peak_luminance <= 0.0 {
+        1.0
+    } else {
+        peak_luminance
+    }
+}

--- a/crates/jxl-color/src/convert/tone_map.rs
+++ b/crates/jxl-color/src/convert/tone_map.rs
@@ -59,12 +59,7 @@ fn tone_map_generic(
     }
 }
 
-fn detect_peak_luminance(
-    r: &[f32],
-    g: &[f32],
-    b: &[f32],
-    luminances: [f32; 3],
-) -> f32 {
+fn detect_peak_luminance(r: &[f32], g: &[f32], b: &[f32], luminances: [f32; 3]) -> f32 {
     #[cfg(target_arch = "x86_64")]
     {
         if std::arch::is_x86_feature_detected!("avx2") {
@@ -88,32 +83,17 @@ fn detect_peak_luminance(
 
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
-unsafe fn detect_peak_luminance_avx2(
-    r: &[f32],
-    g: &[f32],
-    b: &[f32],
-    luminances: [f32; 3],
-) -> f32 {
+unsafe fn detect_peak_luminance_avx2(r: &[f32], g: &[f32], b: &[f32], luminances: [f32; 3]) -> f32 {
     detect_peak_luminance_impl(r, g, b, luminances)
 }
 
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
-unsafe fn detect_peak_luminance_neon(
-    r: &[f32],
-    g: &[f32],
-    b: &[f32],
-    luminances: [f32; 3],
-) -> f32 {
+unsafe fn detect_peak_luminance_neon(r: &[f32], g: &[f32], b: &[f32], luminances: [f32; 3]) -> f32 {
     detect_peak_luminance_impl(r, g, b, luminances)
 }
 
-fn detect_peak_luminance_impl(
-    r: &[f32],
-    g: &[f32],
-    b: &[f32],
-    luminances: [f32; 3],
-) -> f32 {
+fn detect_peak_luminance_impl(r: &[f32], g: &[f32], b: &[f32], luminances: [f32; 3]) -> f32 {
     assert_eq!(r.len(), g.len());
     assert_eq!(g.len(), b.len());
 

--- a/crates/jxl-color/src/gamut.rs
+++ b/crates/jxl-color/src/gamut.rs
@@ -8,11 +8,9 @@ pub(crate) fn map_gamut_generic(
     let [lr, lg, lb] = luminance;
     let y = r * lr + g * lg + b * lb;
 
-    let (gray_saturation, gray_luminance) = rgb
-        .into_iter()
-        .fold(
-            (0f32, 0f32),
-            |(gray_saturation, gray_luminance), v| {
+    let (gray_saturation, gray_luminance) =
+        rgb.into_iter()
+            .fold((0f32, 0f32), |(gray_saturation, gray_luminance), v| {
                 let v_sub_y = v - y;
                 let inv_v_sub_y = (if v_sub_y == 0.0 { 1.0 } else { v_sub_y }).recip();
                 let v_over_v_sub_y = v * inv_v_sub_y;
@@ -26,14 +24,14 @@ pub(crate) fn map_gamut_generic(
                     gray_saturation
                 } else {
                     v_over_v_sub_y - inv_v_sub_y
-                }.max(gray_luminance);
+                }
+                .max(gray_luminance);
 
                 (gray_saturation, gray_luminance)
-            },
-        );
+            });
 
-    let gray_mix = (saturation_factor * (gray_saturation - gray_luminance) + gray_luminance)
-        .clamp(0.0, 1.0);
+    let gray_mix =
+        (saturation_factor * (gray_saturation - gray_luminance) + gray_luminance).clamp(0.0, 1.0);
 
     let mixed_rgb = rgb.map(|v| gray_mix * (y - v) + v);
     let max_color_val = rgb.into_iter().fold(1f32, |max, v| v.max(max));

--- a/crates/jxl-color/src/gamut.rs
+++ b/crates/jxl-color/src/gamut.rs
@@ -1,0 +1,41 @@
+/// Map out-of-gamut RGB samples, ported from libjxl.
+pub(crate) fn map_gamut_generic(
+    rgb: [f32; 3],
+    luminance: [f32; 3],
+    saturation_factor: f32,
+) -> [f32; 3] {
+    let [r, g, b] = rgb;
+    let [lr, lg, lb] = luminance;
+    let y = r * lr + g * lg + b * lb;
+
+    let (gray_saturation, gray_luminance) = rgb
+        .into_iter()
+        .fold(
+            (0f32, 0f32),
+            |(gray_saturation, gray_luminance), v| {
+                let v_sub_y = v - y;
+                let inv_v_sub_y = (if v_sub_y == 0.0 { 1.0 } else { v_sub_y }).recip();
+                let v_over_v_sub_y = v * inv_v_sub_y;
+
+                let gray_saturation = if v_sub_y >= 0.0 {
+                    gray_saturation
+                } else {
+                    gray_saturation.max(v_over_v_sub_y)
+                };
+                let gray_luminance = if v_sub_y <= 0.0 {
+                    gray_saturation
+                } else {
+                    v_over_v_sub_y - inv_v_sub_y
+                }.max(gray_luminance);
+
+                (gray_saturation, gray_luminance)
+            },
+        );
+
+    let gray_mix = (saturation_factor * (gray_saturation - gray_luminance) + gray_luminance)
+        .clamp(0.0, 1.0);
+
+    let mixed_rgb = rgb.map(|v| gray_mix * (y - v) + v);
+    let max_color_val = rgb.into_iter().fold(1f32, |max, v| v.max(max));
+    mixed_rgb.map(|v| v / max_color_val)
+}

--- a/crates/jxl-color/src/lib.rs
+++ b/crates/jxl-color/src/lib.rs
@@ -12,6 +12,7 @@ pub mod consts;
 mod convert;
 mod error;
 mod fastmath;
+mod gamut;
 pub mod header;
 pub mod icc;
 mod tf;

--- a/crates/jxl-color/src/tf.rs
+++ b/crates/jxl-color/src/tf.rs
@@ -1,3 +1,7 @@
+mod rec2408;
+
+pub(crate) use rec2408::rec2408_eetf_generic;
+
 /// Applies gamma to samples.
 pub fn apply_gamma(mut samples: &mut [f32], gamma: f32) {
     #[cfg(target_arch = "aarch64")]

--- a/crates/jxl-color/src/tf/rec2408.rs
+++ b/crates/jxl-color/src/tf/rec2408.rs
@@ -1,16 +1,15 @@
-/// Assumes `intensity_target` is given as max source luminance.
 pub(crate) fn rec2408_eetf_generic(
     from_pq_sample: f32,
+    intensity_target: f32,
     from_luminance_range: (f32, f32),
     to_luminance_range: (f32, f32),
 ) -> f32 {
-    let intensity_target = from_luminance_range.1;
     // Lb, Lw, Lmin, Lmax
     let mut luminances = [
-        from_luminance_range.0,
-        from_luminance_range.1,
-        to_luminance_range.0,
-        to_luminance_range.1,
+        from_luminance_range.0 / intensity_target,
+        from_luminance_range.1 / intensity_target,
+        to_luminance_range.0 / intensity_target,
+        to_luminance_range.1 / intensity_target,
     ];
     super::linear_to_pq(&mut luminances, intensity_target);
 

--- a/crates/jxl-color/src/tf/rec2408.rs
+++ b/crates/jxl-color/src/tf/rec2408.rs
@@ -1,0 +1,49 @@
+/// Assumes `intensity_target` is given as max source luminance.
+pub(crate) fn rec2408_eetf_generic(
+    from_pq_sample: f32,
+    from_luminance_range: (f32, f32),
+    to_luminance_range: (f32, f32),
+) -> f32 {
+    let intensity_target = from_luminance_range.1;
+    // Lb, Lw, Lmin, Lmax
+    let mut luminances = [
+        from_luminance_range.0,
+        from_luminance_range.1,
+        to_luminance_range.0,
+        to_luminance_range.1,
+    ];
+    super::linear_to_pq(&mut luminances, intensity_target);
+
+    // Step 1
+    let source_pq_diff = luminances[1] - luminances[0];
+    let normalized_source_pq_sample = (from_pq_sample - luminances[0]) / source_pq_diff;
+    let min_luminance = (luminances[2] - luminances[0]) / source_pq_diff;
+    let max_luminance = (luminances[3] - luminances[0]) / source_pq_diff;
+
+    // Step 2
+    let ks = 1.5 * max_luminance - 0.5;
+    let b = min_luminance;
+
+    // Step 3
+    let compressed_pq_sample = if normalized_source_pq_sample < ks {
+        normalized_source_pq_sample
+    } else {
+        // Step 4
+        let one_sub_ks = 1.0 - ks;
+        let t = (normalized_source_pq_sample - ks) / one_sub_ks;
+        let t_p2 = t * t;
+        let t_p3 = t_p2 * t;
+        (2.0 * t_p3 - 3.0 * t_p2 + 1.0) * ks
+            + (t_p3 - 2.0 * t_p2 + t) * one_sub_ks
+            + (-2.0 * t_p3 + 3.0 * t_p2) * max_luminance
+    };
+
+    let one_sub_compressed_p4 = {
+        let x = 1f32 - compressed_pq_sample;
+        x * x * x * x
+    };
+    let normalized_target_pq_sample = one_sub_compressed_p4 * b + compressed_pq_sample;
+
+    // Step 5
+    normalized_target_pq_sample * source_pq_diff + luminances[0]
+}

--- a/crates/jxl-render/src/inner.rs
+++ b/crates/jxl-render/src/inner.rs
@@ -326,7 +326,7 @@ fn convert_color_for_record(
                 )),
                 &jxl_color::ColorEncodingWithProfile::new(metadata.colour_encoding.clone()),
                 &metadata.opsin_inverse_matrix,
-                metadata.tone_mapping.intensity_target,
+                &metadata.tone_mapping,
             );
             transform
                 .run(

--- a/crates/jxl-render/src/lib.rs
+++ b/crates/jxl-render/src/lib.rs
@@ -679,7 +679,7 @@ impl RenderContext {
                     &frame_color_encoding,
                     &self.requested_color_encoding,
                     &metadata.opsin_inverse_matrix,
-                    metadata.tone_mapping.intensity_target,
+                    &metadata.tone_mapping,
                 );
 
                 let (color_channels, extra_channels) = grid.buffer_mut().split_at_mut(3);


### PR DESCRIPTION
Resolves #9 

This PR implements:
- Rec.2408 tone mapper with peak detection, YRGB method (which is used by libjxl)
- Gamut mapper, ported from libjxl