### PR TITLE
Add an initial fuzzing harness using cargo-fuzz

### DIFF
--- a/crates/jxl-oxide/fuzz/.gitignore
+++ b/crates/jxl-oxide/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/crates/jxl-oxide/fuzz/Cargo.toml
+++ b/crates/jxl-oxide/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "jxl-oxide-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.jxl-oxide]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "decode"
+path = "fuzz_targets/decode.rs"
+test = false
+doc = false

--- a/crates/jxl-oxide/fuzz/fuzz_targets/decode.rs
+++ b/crates/jxl-oxide/fuzz/fuzz_targets/decode.rs
@@ -1,0 +1,28 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    fuzz_decode(data);
+});
+
+use jxl_oxide::{AllocTracker, JxlImage, JxlThreadPool};
+
+fn fuzz_decode(data: &[u8]) {
+    let image = JxlImage::builder()
+        .pool(JxlThreadPool::none())
+        .alloc_tracker(AllocTracker::with_limit(128 * 1024 * 1024)) // 128 MiB
+        .read(std::io::Cursor::new(data));
+    if let Ok(image) = image {
+        let header = image.image_header();
+        let max_size = u32::max(header.size.width, header.size.height);
+
+        // Skip huge images
+        if max_size > 65536 {
+            return;
+        }
+        for keyframe_idx in 0..image.num_loaded_keyframes() {
+            let _ = image.render_frame(keyframe_idx);
+        }
+    }
+}


### PR DESCRIPTION
Used to discover #163, #164,  #165,  #169,  #170

Heavily based on the honggfuzz target that is already in the repo.

Works best when seeded with valid JPEG XL files with various encoding parameters, rather than starting from scratch. This is my seed corpus: [jxl_fuzzing_seeds.tar.gz](https://github.com/tirr-c/jxl-oxide/files/13852139/jxl_fuzzing_seeds.tar.gz)

I am contributing it along with the seed corpus so that you are no longer dependent on me running it.