### PR TITLE
jxl-oxide: Remove lcms2 requirement from conformance test

### DIFF
--- a/crates/jxl-oxide/Cargo.toml
+++ b/crates/jxl-oxide/Cargo.toml
@@ -69,7 +69,3 @@ features = ["getrandom", "small_rng"]
 version = "0.11.20"
 default-features = false
 features = ["blocking", "rustls-tls"]
-
-[[test]]
-name = "conformance"
-required-features = ["lcms2"]


### PR DESCRIPTION
The tests pass without lcms2.