### PR TITLE
jxl-oxide-cli: Update clap to 4.4.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,9 +143,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.16"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e54881c004cec7895b0068a0a954cd5d62da01aef83fa35b1e594497bf5445"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.16"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cb82d7f531603d2fd1f507441cdd35184fa81beff7bd489570de7f773460bb"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstream",
  "anstyle",

--- a/crates/jxl-oxide-cli/Cargo.toml
+++ b/crates/jxl-oxide-cli/Cargo.toml
@@ -19,7 +19,7 @@ miniz_oxide = "0.7.1"
 png = "0.17.10"
 
 [dependencies.clap]
-version = "4.4.2"
+version = "4.4.18"
 features = ["derive"]
 
 [dependencies.jxl-oxide]


### PR DESCRIPTION
Fixes panic on subcommand-arg conflict.