### PR TITLE
jxl-modular: Try various optimizations

### DIFF
--- a/crates/jxl-modular/src/image.rs
+++ b/crates/jxl-modular/src/image.rs
@@ -420,8 +420,11 @@ impl<'dest, S: Sample> TransformedModularSubimage<'dest, S> {
                 .collect::<Vec<_>>();
             filtered_prev.reverse();
 
-            let ma_tree = self.ma_ctx.make_flat_tree(i as u32, stream_index);
-            loop_fn(grid.grid_mut(), &filtered_prev, ma_tree, wp_header)?;
+            let ma_tree =
+                self.ma_ctx
+                    .make_flat_tree(i as u32, stream_index, filtered_prev.len() as u32);
+            let filtered_prev = &filtered_prev[..ma_tree.max_prev_channel_depth()];
+            loop_fn(grid.grid_mut(), filtered_prev, ma_tree, wp_header)?;
 
             prev.push((info, grid.grid()));
         }

--- a/crates/jxl-modular/src/image.rs
+++ b/crates/jxl-modular/src/image.rs
@@ -521,7 +521,7 @@ impl<'dest, S: Sample> TransformedModularSubimage<'dest, S> {
 
                             let token =
                                 no_lz77_decoder.read_varint_clustered(bitstream, cluster)?;
-                            let value = S::unpack_signed_u32(token) + S::from_i32(pred as i32);
+                            let value = S::unpack_signed_u32(token).add(S::from_i32(pred as i32));
                             *out = value;
                             prev_row_cache.push(value.to_i64());
                             w = value.to_i64();
@@ -534,7 +534,7 @@ impl<'dest, S: Sample> TransformedModularSubimage<'dest, S> {
                         let n = prev_row_cache[0];
                         let pred = n;
                         let token = no_lz77_decoder.read_varint_clustered(bitstream, cluster)?;
-                        let value = S::unpack_signed_u32(token) + S::from_i32(pred as i32);
+                        let value = S::unpack_signed_u32(token).add(S::from_i32(pred as i32));
                         out_row[0] = value;
                         prev_row_cache[0] = value.to_i64();
 
@@ -546,7 +546,7 @@ impl<'dest, S: Sample> TransformedModularSubimage<'dest, S> {
 
                             let token =
                                 no_lz77_decoder.read_varint_clustered(bitstream, cluster)?;
-                            let value = S::unpack_signed_u32(token) + S::from_i32(pred as i32);
+                            let value = S::unpack_signed_u32(token).add(S::from_i32(pred as i32));
                             *out = value;
                             *prev = value.to_i64();
                             nw = n;

--- a/crates/jxl-modular/src/ma.rs
+++ b/crates/jxl-modular/src/ma.rs
@@ -342,24 +342,23 @@ impl FlatMaTree {
         decoder: &mut Decoder,
         properties: &Properties<S>,
         dist_multiplier: u32,
-    ) -> Result<(S, super::predictor::Predictor)> {
+    ) -> Result<(i32, super::predictor::Predictor)> {
         let leaf = self.get_leaf(properties);
         let diff = decoder.read_varint_with_multiplier_clustered(
             bitstream,
             leaf.cluster,
             dist_multiplier,
         )?;
-        let diff =
-            S::unpack_signed_u32(diff).wrapping_muladd_i32(leaf.multiplier as i32, leaf.offset);
+        let diff = unpack_signed(diff).wrapping_muladd_i32(leaf.multiplier as i32, leaf.offset);
         Ok((diff, leaf.predictor))
     }
 
     #[inline]
     pub(crate) fn decode_sample_with_fn<S: Sample>(
         &self,
-        next: &mut impl FnMut(u8) -> Result<S>,
+        next: &mut impl FnMut(u8) -> Result<i32>,
         properties: &Properties<S>,
-    ) -> Result<(S, super::predictor::Predictor)> {
+    ) -> Result<(i32, super::predictor::Predictor)> {
         let leaf = self.get_leaf(properties);
         let diff = next(leaf.cluster)?;
         let diff = diff.wrapping_muladd_i32(leaf.multiplier as i32, leaf.offset);

--- a/crates/jxl-modular/src/predictor.rs
+++ b/crates/jxl-modular/src/predictor.rs
@@ -72,43 +72,43 @@ impl TryFrom<u32> for Predictor {
 }
 
 impl Predictor {
-    pub(super) fn predict<S: Sample>(self, properties: &Properties<S>) -> i64 {
+    pub(super) fn predict<S: Sample>(self, properties: &Properties<S>) -> i32 {
         use Predictor::*;
         let predictor = &*properties.predictor;
 
         match self {
             Zero => 0,
-            West => predictor.w as i64,
-            North => predictor.n as i64,
-            AvgWestAndNorth => (predictor.w as i64 + predictor.n as i64) / 2,
+            West => predictor.w,
+            North => predictor.n,
+            AvgWestAndNorth => ((predictor.w as i64 + predictor.n as i64) / 2) as i32,
             Select => {
                 let n = predictor.n;
                 let w = predictor.w;
                 let nw = predictor.nw;
                 if n.abs_diff(nw) < w.abs_diff(nw) {
-                    w as i64
+                    w
                 } else {
-                    n as i64
+                    n
                 }
             }
             Gradient => {
                 let n = predictor.n as i64;
                 let w = predictor.w as i64;
                 let nw = predictor.nw as i64;
-                (n + w - nw).clamp(w.min(n), w.max(n))
+                (n + w - nw).clamp(w.min(n), w.max(n)) as i32
             }
             SelfCorrecting => {
                 let prediction = properties
                     .prediction()
                     .expect("predict_non_sc called with SelfCorrecting predictor");
-                (prediction + 3) >> 3
+                ((prediction + 3) >> 3) as i32
             }
-            NorthEast => predictor.ne() as i64,
-            NorthWest => predictor.nw as i64,
-            WestWest => predictor.ww() as i64,
-            AvgWestAndNorthWest => (predictor.w as i64 + predictor.nw as i64) / 2,
-            AvgNorthAndNorthWest => (predictor.n as i64 + predictor.nw as i64) / 2,
-            AvgNorthAndNorthEast => (predictor.n as i64 + predictor.ne() as i64) / 2,
+            NorthEast => predictor.ne(),
+            NorthWest => predictor.nw,
+            WestWest => predictor.ww(),
+            AvgWestAndNorthWest => ((predictor.w as i64 + predictor.nw as i64) / 2) as i32,
+            AvgNorthAndNorthWest => ((predictor.n as i64 + predictor.nw as i64) / 2) as i32,
+            AvgNorthAndNorthEast => ((predictor.n as i64 + predictor.ne() as i64) / 2) as i32,
             AvgAll => {
                 let n = predictor.n as i64;
                 let w = predictor.w as i64;
@@ -116,7 +116,7 @@ impl Predictor {
                 let ww = predictor.ww() as i64;
                 let nee = predictor.nee() as i64;
                 let ne = predictor.ne() as i64;
-                (6 * n - 2 * nn + 7 * w + ww + nee + 3 * ne + 8) / 16
+                ((6 * n - 2 * nn + 7 * w + ww + nee + 3 * ne + 8) / 16) as i32
             }
         }
     }
@@ -430,7 +430,7 @@ impl<'p, 'prev, 'a, S: Sample> Properties<'p, 'prev, 'a, S> {
             pred.n,
             pred.w,
             pred.w.wrapping_sub(pred.prev_grad),
-            (pred.w as i64 + pred.n as i64 - pred.nw as i64) as i32,
+            pred.w.wrapping_add(pred.n).wrapping_sub(pred.nw),
             pred.w.wrapping_sub(pred.nw),
             pred.nw.wrapping_sub(pred.n),
             pred.n.wrapping_sub(pred.ne()),

--- a/crates/jxl-modular/src/predictor.rs
+++ b/crates/jxl-modular/src/predictor.rs
@@ -424,7 +424,7 @@ impl<'p, 'prev, 'a, S: Sample> Properties<'p, 'prev, 'a, S> {
             0,
             0,
             pred.y as i32,
-            pred.curr_row.len() as i32,
+            pred.x as i32,
             pred.n.abs(),
             pred.w.abs(),
             pred.n,

--- a/crates/jxl-modular/src/sample.rs
+++ b/crates/jxl-modular/src/sample.rs
@@ -10,9 +10,7 @@ pub trait Sealed: Copy + Default + Send + Sync {
     ) -> Option<&'a mut CutGrid<'g, i16>>;
 }
 
-pub trait Sample:
-    Copy + Default + Send + Sync + Sealed  + 'static
-{
+pub trait Sample: Copy + Default + Send + Sync + Sealed + 'static {
     fn from_i32(value: i32) -> Self;
     fn from_u32(value: u32) -> Self;
     fn unpack_signed_u32(value: u32) -> Self;

--- a/crates/jxl-modular/src/sample.rs
+++ b/crates/jxl-modular/src/sample.rs
@@ -20,6 +20,7 @@ pub trait Sample:
     fn to_i64(self) -> i64;
     fn to_f32(self) -> f32;
     fn wrapping_muladd_i32(self, mul: i32, add: i32) -> Self;
+    fn grad_clamped(n: Self, w: Self, nw: Self) -> Self;
 }
 
 impl Sample for i32 {
@@ -56,6 +57,16 @@ impl Sample for i32 {
     #[inline]
     fn wrapping_muladd_i32(self, mul: i32, add: i32) -> i32 {
         self.wrapping_mul(mul).wrapping_add(add)
+    }
+
+    #[inline]
+    fn grad_clamped(n: i32, w: i32, nw: i32) -> i32 {
+        let (n, w) = if w > n {
+            (w as i64, n as i64)
+        } else {
+            (n as i64, w as i64)
+        };
+        (w + n - nw as i64).clamp(w, n) as i32
     }
 }
 
@@ -96,6 +107,16 @@ impl Sample for i16 {
     #[inline]
     fn wrapping_muladd_i32(self, mul: i32, add: i32) -> i16 {
         self.wrapping_mul(mul as i16).wrapping_add(add as i16)
+    }
+
+    #[inline]
+    fn grad_clamped(n: i16, w: i16, nw: i16) -> i16 {
+        let (n, w) = if w > n {
+            (w as i32, n as i32)
+        } else {
+            (n as i32, w as i32)
+        };
+        (w + n - nw as i32).clamp(w, n) as i16
     }
 }
 

--- a/crates/jxl-modular/src/sample.rs
+++ b/crates/jxl-modular/src/sample.rs
@@ -11,7 +11,7 @@ pub trait Sealed: Copy + Default + Send + Sync {
 }
 
 pub trait Sample:
-    Copy + Default + Send + Sync + Sealed + std::ops::Add<Self, Output = Self> + 'static
+    Copy + Default + Send + Sync + Sealed  + 'static
 {
     fn from_i32(value: i32) -> Self;
     fn from_u32(value: u32) -> Self;
@@ -19,6 +19,7 @@ pub trait Sample:
     fn to_i32(self) -> i32;
     fn to_i64(self) -> i64;
     fn to_f32(self) -> f32;
+    fn add(self, rhs: Self) -> Self;
     fn wrapping_muladd_i32(self, mul: i32, add: i32) -> Self;
     fn grad_clamped(n: Self, w: Self, nw: Self) -> Self;
 }
@@ -52,6 +53,11 @@ impl Sample for i32 {
     #[inline]
     fn to_f32(self) -> f32 {
         self as f32
+    }
+
+    #[inline]
+    fn add(self, rhs: i32) -> i32 {
+        self.wrapping_add(rhs)
     }
 
     #[inline]
@@ -102,6 +108,11 @@ impl Sample for i16 {
     #[inline]
     fn to_f32(self) -> f32 {
         self as f32
+    }
+
+    #[inline]
+    fn add(self, rhs: i16) -> i16 {
+        self.wrapping_add(rhs)
     }
 
     #[inline]

--- a/crates/jxl-modular/src/transform.rs
+++ b/crates/jxl-modular/src/transform.rs
@@ -355,12 +355,13 @@ impl Palette {
         } else {
             None
         };
-        let mut predictor = PredictorState::new(width as u32, 0, 0, 0, wp_header);
+        let mut predictor = PredictorState::<S>::new();
+        predictor.reset(width as u32, &[], wp_header);
 
         let mut idx = 0;
         for y in 0..height {
             for x in 0..width {
-                let properties = predictor.properties(&[]);
+                let properties = predictor.properties();
                 let sample = grid.get_mut(x, y);
                 let mut sample_value = sample.to_i32();
                 if need_delta[idx] == (x, y) {

--- a/crates/jxl-modular/src/transform.rs
+++ b/crates/jxl-modular/src/transform.rs
@@ -366,7 +366,7 @@ impl Palette {
                 let mut sample_value = sample.to_i32();
                 if need_delta[idx] == (x, y) {
                     let diff = d_pred.predict(&properties);
-                    sample_value = (sample_value as i64 + diff) as i32;
+                    sample_value = sample_value.wrapping_add(diff);
                     *sample = S::from_i32(sample_value);
                     idx += 1;
                     if idx >= need_delta.len() {


### PR DESCRIPTION
<details>
<summary>Benchmark result (x86_64)</summary>

```
lumine-paimon.d0-e7/preferred-color
                        time:   [102.55 ms 103.09 ms 103.67 ms]
                        thrpt:  [17.127 Melem/s 17.224 Melem/s 17.315 Melem/s]
                 change:
                        time:   [-2.3218% -1.5582% -0.7626%] (p = 0.00 < 0.05)
                        thrpt:  [+0.7684% +1.5829% +2.3770%]
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

minecraft.d0-e6/preferred-color
                        time:   [89.826 ms 90.212 ms 90.599 ms]
                        thrpt:  [40.689 Melem/s 40.864 Melem/s 41.039 Melem/s]
                 change:
                        time:   [-7.9255% -7.3408% -6.7342%] (p = 0.00 < 0.05)
                        thrpt:  [+7.2205% +7.9224% +8.6077%]
                        Performance has improved.

srgb.d0-e1/preferred-color
                        time:   [12.066 ms 12.103 ms 12.144 ms]
                        thrpt:  [118.28 Melem/s 118.68 Melem/s 119.04 Melem/s]
                 change:
                        time:   [-6.1269% -5.7340% -5.3368%] (p = 0.00 < 0.05)
                        thrpt:  [+5.6377% +6.0828% +6.5268%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

nahida-motion.d1-e7/preferred-color
                        time:   [57.398 ms 57.479 ms 57.560 ms]
                        thrpt:  [64.044 Melem/s 64.135 Melem/s 64.225 Melem/s]
                 change:
                        time:   [-3.0342% -2.8442% -2.6579%] (p = 0.00 < 0.05)
                        thrpt:  [+2.7304% +2.9275% +3.1292%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild

starrail.d1-e6/preferred-color
                        time:   [57.377 ms 57.474 ms 57.574 ms]
                        thrpt:  [64.029 Melem/s 64.141 Melem/s 64.249 Melem/s]
                 change:
                        time:   [-2.7467% -2.5262% -2.3053%] (p = 0.00 < 0.05)
                        thrpt:  [+2.3597% +2.5917% +2.8243%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

genshin-cafe.d2-e6-epf2/preferred-color
                        time:   [94.150 ms 94.309 ms 94.471 ms]
                        thrpt:  [71.641 Melem/s 71.764 Melem/s 71.885 Melem/s]
                 change:
                        time:   [-4.7657% -4.3981% -4.0614%] (p = 0.00 < 0.05)
                        thrpt:  [+4.2333% +4.6004% +5.0042%]
                        Performance has improved.

genshin-cafe.d2-e6-epf3/preferred-color
                        time:   [114.02 ms 114.28 ms 114.62 ms]
                        thrpt:  [59.046 Melem/s 59.222 Melem/s 59.359 Melem/s]
                 change:
                        time:   [+4.1649% +4.4929% +4.8871%] (p = 0.00 < 0.05)
                        thrpt:  [-4.6594% -4.2998% -3.9984%]
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
```

Result of `genshin-cafe.d2-e6-epf3` seems a bit off...
</details>