### PR TITLE
jxl-color: Make peak detection non-default, add an option to pass sRGB samples to CMS

### DIFF
--- a/crates/jxl-color/src/cms.rs
+++ b/crates/jxl-color/src/cms.rs
@@ -26,6 +26,14 @@ pub trait ColorManagementSystem {
         self.transform_impl(from, to, intent, channels)
             .map_err(crate::Error::CmsFailure)
     }
+
+    /// Returns whether the CMS supports linear transfer function.
+    ///
+    /// This method will return `false` if it doesn't support (or it lacks precision to handle)
+    /// linear transfer function.
+    fn supports_linear_tf(&self) -> bool {
+        true
+    }
 }
 
 /// "Null" color management system that fails on every operation.

--- a/crates/jxl-color/src/convert/tone_map.rs
+++ b/crates/jxl-color/src/convert/tone_map.rs
@@ -772,7 +772,36 @@ mod tests {
             intensity_target: 10000.0,
             min_nits: 0.0,
         };
-        tone_map(&mut r, &mut g, &mut b, &hdr_params, 255.0);
+        tone_map(&mut r, &mut g, &mut b, &hdr_params, 255.0, false);
+
+        dbg!(r);
+        dbg!(g);
+        dbg!(b);
+
+        for (idx, ((r, g), b)) in r.into_iter().zip(b).zip(b).enumerate() {
+            let expected = (idx / 5) as f32 * 0.8714331;
+            assert!((r - expected).abs() < 2e-5);
+            assert!((g - expected).abs() < 2e-5);
+            assert!((b - expected).abs() < 2e-5);
+        }
+    }
+
+    #[test]
+    fn tone_map_range_detect_peak() {
+        let mut samples = [0f32; 10];
+        for (idx, v) in samples.iter_mut().enumerate() {
+            *v = (idx / 5) as f32 * 0.1;
+        }
+        let mut r = samples;
+        let mut g = samples;
+        let mut b = samples;
+
+        let hdr_params = HdrParams {
+            luminances: [0.2126, 0.7152, 0.0722],
+            intensity_target: 10000.0,
+            min_nits: 0.0,
+        };
+        tone_map(&mut r, &mut g, &mut b, &hdr_params, 255.0, true);
 
         dbg!(r);
         dbg!(g);

--- a/crates/jxl-render/src/lib.rs
+++ b/crates/jxl-render/src/lib.rs
@@ -793,7 +793,9 @@ impl RenderContext {
                     jxl_color::ycbcr_to_rgb([cb, y, cr]);
                 }
 
-                let transform = jxl_color::ColorTransform::new(
+                let mut transform = jxl_color::ColorTransform::builder();
+                transform.set_srgb_icc(!self.cms.supports_linear_tf());
+                let transform = transform.build(
                     &frame_color_encoding,
                     &self.requested_color_encoding,
                     &metadata.opsin_inverse_matrix,


### PR DESCRIPTION
This might help qcms implementation.