### PR TITLE
jxl-modular: Include meta channels when computing dist_multiplier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `jxl-modular`: Include meta channels when computing LZ77 `dist_multiplier` (#269).
+
 ## [0.7.1] - 2024-02-29
 
 ### Fixed

--- a/crates/jxl-modular/src/image.rs
+++ b/crates/jxl-modular/src/image.rs
@@ -627,7 +627,6 @@ impl<'dest, S: Sample> TransformedModularSubimage<'dest, S> {
         let dist_multiplier = self
             .channel_info
             .iter()
-            .skip_while(|ch| ch.hshift == -1 || ch.vshift == -1)
             .map(|info| info.width)
             .max()
             .unwrap_or(0);


### PR DESCRIPTION
This is more like a bug in libjxl, but it's not really possible to "fix" libjxl at this point.

Fixes #268 