### PR TITLE
jxl-oxide-wasm: Update packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,8 +106,7 @@ jobs:
       - name: Build WebAssembly module
         working-directory: crates/jxl-oxide-wasm
         run: |
-          wasm-pack build --release --target web
-          RUSTFLAGS='-C target-feature=+simd128' wasm-pack build --release --target web -d pkg/simd128 --no-pack --no-typescript
+          RUSTFLAGS='-C target-feature=+simd128' wasm-pack build --release --target web --weak-refs --reference-types
           node ./update-package-json.mjs
           wasm-pack pack
       - uses: actions/upload-artifact@v4

--- a/crates/jxl-oxide-wasm/README.md
+++ b/crates/jxl-oxide-wasm/README.md
@@ -13,7 +13,3 @@ await init();
 // Use `JxlImage` after initialization.
 const image = new JxlImage();
 ```
-
-## WebAssembly SIMD support
-This package also provides WebAssembly module with SIMD enabled. Import `jxl-oxide-wasm/simd128`
-instead.

--- a/crates/jxl-oxide-wasm/update-package-json.mjs
+++ b/crates/jxl-oxide-wasm/update-package-json.mjs
@@ -13,25 +13,16 @@ packageJson.exports = {
     types: './jxl_oxide_wasm.d.ts',
     import: './jxl_oxide_wasm.js'
   },
-  './simd128': {
-    types: './jxl_oxide_wasm.d.ts',
-    import: './simd128/jxl_oxide_wasm.js'
-  },
   './module.wasm': {
     types: './jxl_oxide_wasm_bg.wasm.d.ts',
     import: './jxl_oxide_wasm_bg.wasm'
   },
-  './simd128/module.wasm': {
-    types: './jxl_oxide_wasm_bg.wasm.d.ts',
-    import: './simd128/jxl_oxide_wasm_bg.wasm'
-  },
 };
 packageJson.files = [
-  'jxl_oxide_wasm_bg.wasm',
   'jxl_oxide_wasm.js',
   'jxl_oxide_wasm.d.ts',
-  'simd128/jxl_oxide_wasm_bg.wasm',
-  'simd128/jxl_oxide_wasm.js',
+  'jxl_oxide_wasm_bg.wasm',
+  'jxl_oxide_wasm_bg.wasm.d.ts',
   'LICENSE-APACHE',
   'LICENSE-MIT',
   'README.md',


### PR DESCRIPTION
Include only simd128 builds, enable WeakRef and reference types in bindings.