### PR TITLE
jxl-render: Load VarDCT passes in parallel

### DIFF
--- a/crates/jxl-frame/src/data/pass_group.rs
+++ b/crates/jxl-frame/src/data/pass_group.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::AtomicI32;
+
 use jxl_bitstream::Bitstream;
 use jxl_grid::{AllocTracker, SharedSubgrid};
 use jxl_modular::{image::TransformedModularSubimage, ChannelShift, MaConfig, Sample};
@@ -25,7 +27,7 @@ pub struct PassGroupParams<'frame, 'buf, 'g, 'tracker, S: Sample> {
 pub struct PassGroupParamsVardct<'frame, 'buf, 'g> {
     pub lf_vardct: &'frame LfGlobalVarDct,
     pub hf_global: &'frame HfGlobal,
-    pub hf_coeff_output: &'buf [SharedSubgrid<'g, f32>; 3],
+    pub hf_coeff_output: &'buf [SharedSubgrid<'g, AtomicI32>; 3],
 }
 
 pub fn decode_pass_group<S: Sample>(

--- a/crates/jxl-frame/src/data/pass_group.rs
+++ b/crates/jxl-frame/src/data/pass_group.rs
@@ -1,5 +1,5 @@
 use jxl_bitstream::Bitstream;
-use jxl_grid::{AllocTracker, CutGrid};
+use jxl_grid::{AllocTracker, SharedSubgrid};
 use jxl_modular::{image::TransformedModularSubimage, ChannelShift, MaConfig, Sample};
 use jxl_threadpool::JxlThreadPool;
 use jxl_vardct::{write_hf_coeff, HfCoeffParams};
@@ -25,7 +25,7 @@ pub struct PassGroupParams<'frame, 'buf, 'g, 'tracker, S: Sample> {
 pub struct PassGroupParamsVardct<'frame, 'buf, 'g> {
     pub lf_vardct: &'frame LfGlobalVarDct,
     pub hf_global: &'frame HfGlobal,
-    pub hf_coeff_output: &'buf mut [CutGrid<'g, f32>; 3],
+    pub hf_coeff_output: &'buf [SharedSubgrid<'g, f32>; 3],
 }
 
 pub fn decode_pass_group<S: Sample>(

--- a/crates/jxl-grid/src/simple_grid.rs
+++ b/crates/jxl-grid/src/simple_grid.rs
@@ -166,6 +166,17 @@ impl<'g, V: Copy> CutGrid<'g, V> {
         }
     }
 
+    pub fn empty() -> Self {
+        Self {
+            ptr: NonNull::dangling(),
+            split_base: None,
+            width: 0,
+            height: 0,
+            stride: 0,
+            _marker: Default::default(),
+        }
+    }
+
     /// Create a `CutGrid` from buffer slice, width, height and stride.
     ///
     /// # Panic

--- a/crates/jxl-grid/src/simple_grid.rs
+++ b/crates/jxl-grid/src/simple_grid.rs
@@ -197,6 +197,11 @@ impl<'g, V: Copy> CutGrid<'g, V> {
     }
 
     #[inline]
+    pub fn into_ptr(self) -> NonNull<V> {
+        self.ptr
+    }
+
+    #[inline]
     pub fn width(&self) -> usize {
         self.width
     }
@@ -276,6 +281,11 @@ impl<'g, V: Copy> CutGrid<'g, V> {
     pub fn borrow_mut(&mut self) -> CutGrid<V> {
         // SAFETY: We have unique reference to the grid, and the new grid borrows it.
         unsafe { CutGrid::new(self.ptr, self.width, self.height, self.stride) }
+    }
+
+    pub fn as_shared(&self) -> SharedSubgrid<V> {
+        // SAFETY: We have unique reference to the grid.
+        unsafe { SharedSubgrid::new(self.ptr, self.width, self.height, self.stride) }
     }
 
     pub fn subgrid_mut(

--- a/crates/jxl-grid/src/subgrid.rs
+++ b/crates/jxl-grid/src/subgrid.rs
@@ -1,4 +1,4 @@
-use std::{ops::RangeBounds, ptr::NonNull};
+use std::{ops::RangeBounds, ptr::NonNull, sync::atomic::AtomicI32};
 
 use crate::SimdVector;
 
@@ -196,5 +196,22 @@ impl<'g> SharedSubgrid<'g, f32> {
                 stride: self.stride / V::SIZE,
                 _marker: Default::default(),
             })
+    }
+
+    /// # Safety
+    /// Caller should make sure that atomic and non-atomic accesses are not mixed.
+    pub unsafe fn as_atomic_i32(&self) -> SharedSubgrid<'g, AtomicI32> {
+        assert_eq!(std::mem::size_of::<f32>(), std::mem::size_of::<AtomicI32>());
+        assert_eq!(
+            std::mem::align_of::<f32>(),
+            std::mem::align_of::<AtomicI32>()
+        );
+        SharedSubgrid {
+            ptr: self.ptr.cast(),
+            width: self.width,
+            height: self.height,
+            stride: self.stride,
+            _marker: Default::default(),
+        }
     }
 }

--- a/crates/jxl-render/src/modular.rs
+++ b/crates/jxl-render/src/modular.rs
@@ -50,15 +50,14 @@ pub(crate) fn render_modular<S: Sample>(
             scope.spawn(|_| {
                 let r = util::load_lf_groups(
                     frame,
-                    lf_global.vardct.as_ref(),
+                    lf_global,
                     lf_groups,
-                    gmodular.ma_config.as_ref(),
                     lf_group_image,
                     modular_region.downsample(3),
                     pool,
                 );
-                if r.is_err() {
-                    *result.write().unwrap() = r;
+                if let Err(e) = r {
+                    *result.write().unwrap() = Err(e);
                 }
             });
 

--- a/crates/jxl-render/src/vardct/mod.rs
+++ b/crates/jxl-render/src/vardct/mod.rs
@@ -57,8 +57,6 @@ pub(crate) fn render_vardct<S: Sample>(
     let tracker = frame.alloc_tracker();
 
     let jpeg_upsampling = frame_header.jpeg_upsampling;
-    let shifts_cbycr: [_; 3] =
-        std::array::from_fn(|idx| ChannelShift::from_jpeg_upsampling(jpeg_upsampling, idx));
     let subsampled = jpeg_upsampling.into_iter().any(|x| x != 0);
 
     let lf_global = if let Some(x) = &cache.lf_global {
@@ -141,9 +139,8 @@ pub(crate) fn render_vardct<S: Sample>(
 
     let group_dim = frame_header.group_dim();
     let lf_groups = &mut cache.lf_groups;
-    let mut lf_xyb =
-        ImageWithRegion::from_region_and_tracker(3, modular_lf_region, false, tracker)?;
 
+    let mut lf_xyb = None;
     let result = std::sync::RwLock::new(Result::Ok(()));
     pool.scope(|scope| {
         let hf_global = &mut cache.hf_global;
@@ -154,8 +151,8 @@ pub(crate) fn render_vardct<S: Sample>(
                     Ok(())
                 });
 
-                if r.is_err() {
-                    *result.write().unwrap() = r;
+                if let Err(e) = r {
+                    *result.write().unwrap() = Err(e);
                 }
             });
         }
@@ -163,116 +160,55 @@ pub(crate) fn render_vardct<S: Sample>(
         let r = tracing::trace_span!("Load LF groups").in_scope(|| {
             util::load_lf_groups(
                 frame,
-                lf_global.vardct.as_ref(),
+                lf_global,
                 lf_groups,
-                gmodular.ma_config.as_ref(),
                 lf_group_image,
                 modular_lf_region,
                 pool,
             )
         });
-        if r.is_err() {
-            *result.write().unwrap() = r;
-            return;
-        }
-
-        let r = if let Some(x) = lf_frame {
-            tracing::trace_span!("Copy LFQuant").in_scope(|| -> Result<_> {
-                let [lf_x, lf_y, lf_b] = lf_xyb.buffer_mut() else {
-                    panic!()
-                };
-
-                let lf_frame = std::sync::Arc::clone(&x.image).run_with_image()?;
-                let lf_frame = lf_frame.blend(None, pool)?;
-                lf_frame.clone_region_channel(modular_lf_region, 0, lf_x);
-                lf_frame.clone_region_channel(modular_lf_region, 1, lf_y);
-                lf_frame.clone_region_channel(modular_lf_region, 2, lf_b);
-                Ok(())
-            })
-        } else {
-            tracing::trace_span!("Dequant LF image").in_scope(|| -> Result<_> {
-                let [lf_x, lf_y, lf_b] = lf_xyb.buffer_mut() else {
-                    panic!()
-                };
-
-                let lf_groups_per_row = frame_header.lf_groups_per_row();
-                for idx in 0..frame_header.num_lf_groups() {
-                    let Some(lf_group) = lf_groups.get(&idx) else {
-                        continue;
-                    };
-
-                    let lf_group_x = idx % lf_groups_per_row;
-                    let lf_group_y = idx / lf_groups_per_row;
-                    let left = lf_group_x * frame_header.group_dim();
-                    let top = lf_group_y * frame_header.group_dim();
-                    let lf_group_region = Region {
-                        left: left as i32,
-                        top: top as i32,
-                        width: group_dim,
-                        height: group_dim,
-                    };
-                    if modular_lf_region.intersection(lf_group_region).is_empty() {
-                        continue;
-                    }
-
-                    let left = left - modular_lf_region.left as u32;
-                    let top = top - modular_lf_region.top as u32;
-
-                    let quantizer = &lf_global_vardct.quantizer;
-                    let lf_coeff = lf_group.lf_coeff.as_ref().unwrap();
-                    let channel_data = lf_coeff.lf_quant.image().unwrap().image_channels();
-                    copy_lf_dequant(
-                        lf_x,
-                        left as usize >> shifts_cbycr[0].hshift(),
-                        top as usize >> shifts_cbycr[0].vshift(),
-                        quantizer,
-                        lf_global.lf_dequant.m_x_lf,
-                        &channel_data[1],
-                        lf_coeff.extra_precision,
-                    );
-                    copy_lf_dequant(
-                        lf_y,
-                        left as usize >> shifts_cbycr[1].hshift(),
-                        top as usize >> shifts_cbycr[1].vshift(),
-                        quantizer,
-                        lf_global.lf_dequant.m_y_lf,
-                        &channel_data[0],
-                        lf_coeff.extra_precision,
-                    );
-                    copy_lf_dequant(
-                        lf_b,
-                        left as usize >> shifts_cbycr[2].hshift(),
-                        top as usize >> shifts_cbycr[2].vshift(),
-                        quantizer,
-                        lf_global.lf_dequant.m_b_lf,
-                        &channel_data[2],
-                        lf_coeff.extra_precision,
-                    );
-                }
-
-                if !subsampled {
-                    chroma_from_luma_lf(lf_xyb.buffer_mut(), &lf_global_vardct.lf_chan_corr);
-                }
-
-                if !frame_header.flags.skip_adaptive_lf_smoothing() {
-                    adaptive_lf_smoothing(
-                        lf_xyb.buffer_mut(),
-                        &lf_global.lf_dequant,
-                        &lf_global_vardct.quantizer,
-                    )?;
-                }
-
-                Ok(())
-            })
-        };
-
-        if r.is_err() {
-            *result.write().unwrap() = r;
-        }
+        lf_xyb = Some(match r {
+            Ok(x) => x.unwrap(),
+            Err(e) => {
+                *result.write().unwrap() = Err(e);
+                return;
+            }
+        });
     });
     result.into_inner().unwrap()?;
-
+    let mut lf_xyb = lf_xyb.unwrap();
     let hf_global = cache.hf_global.as_ref();
+
+    if let Some(x) = lf_frame {
+        tracing::trace_span!("Copy LFQuant").in_scope(|| -> Result<_> {
+            let [lf_x, lf_y, lf_b] = lf_xyb.buffer_mut() else {
+                panic!()
+            };
+
+            let lf_frame = std::sync::Arc::clone(&x.image).run_with_image()?;
+            let lf_frame = lf_frame.blend(None, pool)?;
+            lf_frame.clone_region_channel(modular_lf_region, 0, lf_x);
+            lf_frame.clone_region_channel(modular_lf_region, 1, lf_y);
+            lf_frame.clone_region_channel(modular_lf_region, 2, lf_b);
+            Ok(())
+        })?;
+    } else {
+        if !subsampled {
+            tracing::trace_span!("LF CfL").in_scope(|| {
+                chroma_from_luma_lf(lf_xyb.buffer_mut(), &lf_global_vardct.lf_chan_corr);
+            });
+        }
+
+        if !frame_header.flags.skip_adaptive_lf_smoothing() {
+            tracing::trace_span!("Adaptive LF smoothing").in_scope(|| {
+                adaptive_lf_smoothing(
+                    lf_xyb.buffer_mut(),
+                    &lf_global.lf_dequant,
+                    &lf_global_vardct.quantizer,
+                )
+            })?;
+        }
+    }
 
     let it = tracing::trace_span!("Prepare PassGroup").in_scope(|| {
         fb_xyb
@@ -432,24 +368,22 @@ pub(crate) fn render_vardct<S: Sample>(
 }
 
 pub fn copy_lf_dequant<S: Sample>(
-    out: &mut SimpleGrid<f32>,
-    left: usize,
-    top: usize,
+    grid: &mut CutGrid<f32>,
     quantizer: &Quantizer,
     m_lf: f32,
     channel_data: &SimpleGrid<S>,
     extra_precision: u8,
 ) {
     debug_assert!(extra_precision < 4);
+    assert!(grid.width() >= channel_data.width());
+    assert!(grid.height() >= channel_data.height());
+
     let precision_scale = 1i32 << (9 - extra_precision);
     let scale_inv = quantizer.global_scale as u64 * quantizer.quant_lf as u64;
     let scale = (m_lf as f64 * precision_scale as f64 / scale_inv as f64) as f32;
 
     let width = channel_data.width();
     let height = channel_data.height();
-    let stride = out.width();
-    let buf = &mut out.buf_mut()[top * stride + left..];
-    let mut grid = CutGrid::from_buf(buf, width, height, stride);
     let buf = channel_data.buf();
     for y in 0..height {
         let row = grid.get_row_mut(y);


### PR DESCRIPTION
Benchmark:
- Baseline: `main` (f17d6b4)
- Ryzen 5600X, Arch Linux on Hyper-V VM
- mimalloc is used for both measurements

<details>
<summary>Benchmark result</summary>

```
nahida-motion.d1-e7/preferred-color
                        time:   [49.241 ms 49.445 ms 49.698 ms]
                        thrpt:  [74.176 Melem/s 74.555 Melem/s 74.864 Melem/s]
                 change:
                        time:   [-8.7105% -8.0220% -7.2916%] (p = 0.00 < 0.05)
                        thrpt:  [+7.8651% +8.7216% +9.5416%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

starrail.d1-e6/preferred-color
                        time:   [49.373 ms 49.515 ms 49.664 ms]
                        thrpt:  [74.227 Melem/s 74.451 Melem/s 74.664 Melem/s]
                 change:
                        time:   [-7.7917% -7.2560% -6.7493%] (p = 0.00 < 0.05)
                        thrpt:  [+7.2378% +7.8237% +8.4501%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  7 (7.00%) high mild

genshin-cafe.d2-e6-epf2/preferred-color
                        time:   [83.000 ms 83.243 ms 83.498 ms]
                        thrpt:  [81.056 Melem/s 81.304 Melem/s 81.542 Melem/s]
                 change:
                        time:   [-7.7618% -7.3540% -6.9604%] (p = 0.00 < 0.05)
                        thrpt:  [+7.4811% +7.9377% +8.4149%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

genshin-cafe.d2-e6-epf3/preferred-color
                        time:   [92.674 ms 92.957 ms 93.261 ms]
                        thrpt:  [72.570 Melem/s 72.808 Melem/s 73.030 Melem/s]
                 change:
                        time:   [-7.1353% -6.7624% -6.3840%] (p = 0.00 < 0.05)
                        thrpt:  [+6.8193% +7.2529% +7.6836%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```
</details>