### PR TITLE
jxl-grid: Reorganize modules

### DIFF
--- a/crates/jxl-color/src/ycbcr.rs
+++ b/crates/jxl-color/src/ycbcr.rs
@@ -1,9 +1,9 @@
-use jxl_grid::SimpleGrid;
+use jxl_grid::AlignedGrid;
 
 /// Applies transform from YCbCr to RGB.
 ///
 /// Channels are expected to be in CbYCr order.
-pub fn ycbcr_to_rgb(fb_cbycr: [&mut SimpleGrid<f32>; 3]) {
+pub fn ycbcr_to_rgb(fb_cbycr: [&mut AlignedGrid<f32>; 3]) {
     let [cb, y, cr] = fb_cbycr;
     let cb = cb.buf_mut();
     let y = y.buf_mut();

--- a/crates/jxl-frame/src/data/pass_group.rs
+++ b/crates/jxl-frame/src/data/pass_group.rs
@@ -78,7 +78,7 @@ pub fn decode_pass_group<S: Sample>(
         let block_height = (block_info.height() - block_top).min(group_dim_blocks);
 
         let jpeg_upsampling = frame_header.jpeg_upsampling;
-        let block_info = block_info.subgrid(
+        let block_info = block_info.as_subgrid().subgrid(
             block_left..(block_left + block_width),
             block_top..(block_top + block_height),
         );
@@ -92,7 +92,7 @@ pub fn decode_pass_group<S: Sample>(
                 let block_top = block_top >> shift.vshift();
                 let (block_width, block_height) =
                     shift.shift_size((block_width as u32, block_height as u32));
-                lf_quant.subgrid(
+                lf_quant.as_subgrid().subgrid(
                     block_left..(block_left + block_width as usize),
                     block_top..(block_top + block_height as usize),
                 )

--- a/crates/jxl-grid/README.md
+++ b/crates/jxl-grid/README.md
@@ -1,4 +1,3 @@
 # jxl-grid
 
-This crate provides `Grid`, `SimpleGrid`, `CutGrid` and `PaddedGrid`, used in various places
-involving images.
+This crate provides `AlignedGrid` and `PaddedGrid`, used in various places involving images.

--- a/crates/jxl-grid/src/lib.rs
+++ b/crates/jxl-grid/src/lib.rs
@@ -1,13 +1,13 @@
-//! This crate provides [`SimpleGrid`], [`CutGrid`] and [`PaddedGrid`], used in various
-//! places involving images.
+//! This crate provides [`AlignedGrid`] and [`PaddedGrid`], used in various places involving
+//! images.
 mod alloc_tracker;
+mod mutable_subgrid;
+mod shared_subgrid;
 mod simd;
-mod simple_grid;
-mod subgrid;
 pub use alloc_tracker::*;
+pub use mutable_subgrid::*;
+pub use shared_subgrid::*;
 pub use simd::SimdVector;
-pub use simple_grid::*;
-pub use subgrid::*;
 
 #[derive(Debug)]
 pub enum Error {
@@ -20,6 +20,256 @@ impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::OutOfMemory(bytes) => write!(f, "failed to allocate {bytes} byte(s)"),
+        }
+    }
+}
+
+/// A continuous buffer in the "raster order".
+///
+/// The buffer is aligned so that it can be used in SIMD instructions.
+pub struct AlignedGrid<S> {
+    width: usize,
+    height: usize,
+    offset: usize,
+    buf: Vec<S>,
+    handle: Option<AllocHandle>,
+}
+
+impl<S> std::fmt::Debug for AlignedGrid<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AlignedGrid")
+            .field("width", &self.width)
+            .field("height", &self.height)
+            .field("offset", &self.offset)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<S> AlignedGrid<S> {
+    #[inline]
+    pub fn empty() -> Self {
+        Self {
+            width: 0,
+            height: 0,
+            offset: 0,
+            buf: Vec::new(),
+            handle: None,
+        }
+    }
+}
+
+impl<S: Default + Clone> AlignedGrid<S> {
+    const ALIGN: usize = 32;
+
+    /// Create a new buffer, recording the allocation if a tracker is given.
+    #[inline]
+    pub fn with_alloc_tracker(
+        width: usize,
+        height: usize,
+        tracker: Option<&AllocTracker>,
+    ) -> Result<Self, Error> {
+        let len = width * height;
+        let buf_len = len + (Self::ALIGN - 1) / std::mem::size_of::<S>();
+        let handle = tracker
+            .map(|tracker| tracker.alloc::<S>(buf_len))
+            .transpose()?;
+        let mut buf = vec![S::default(); buf_len];
+
+        let extra = buf.as_ptr() as usize & (Self::ALIGN - 1);
+        let offset = ((Self::ALIGN - extra) % Self::ALIGN) / std::mem::size_of::<S>();
+        buf.resize_with(len + offset, S::default);
+
+        Ok(Self {
+            width,
+            height,
+            offset,
+            buf,
+            handle,
+        })
+    }
+
+    #[inline]
+    fn empty_aligned(
+        width: usize,
+        height: usize,
+        tracker: Option<&AllocTracker>,
+    ) -> Result<Self, Error> {
+        let len = width * height;
+        let buf_len = len + (Self::ALIGN - 1) / std::mem::size_of::<S>();
+        let handle = tracker
+            .map(|tracker| tracker.alloc::<S>(buf_len))
+            .transpose()?;
+        let mut buf = Vec::with_capacity(buf_len);
+
+        let extra = buf.as_ptr() as usize & (Self::ALIGN - 1);
+        let offset = ((Self::ALIGN - extra) % Self::ALIGN) / std::mem::size_of::<S>();
+        buf.resize_with(offset, S::default);
+
+        Ok(Self {
+            width,
+            height,
+            offset,
+            buf,
+            handle,
+        })
+    }
+
+    /// Clones the buffer without recording an allocation.
+    pub fn clone_untracked(&self) -> Self {
+        let mut out = Self::empty_aligned(self.width, self.height, None).unwrap();
+        out.buf.extend_from_slice(self.buf());
+        out
+    }
+
+    /// Tries to clone the buffer, and records the allocation in the same tracker as the original
+    /// buffer.
+    pub fn try_clone(&self) -> Result<Self, Error> {
+        let mut out = Self::empty_aligned(self.width, self.height, self.tracker().as_ref())?;
+        out.buf.extend_from_slice(self.buf());
+        Ok(out)
+    }
+}
+
+impl<S> AlignedGrid<S> {
+    #[inline]
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    #[inline]
+    pub fn height(&self) -> usize {
+        self.height
+    }
+
+    #[inline]
+    pub fn tracker(&self) -> Option<AllocTracker> {
+        self.handle.as_ref().map(|handle| handle.tracker())
+    }
+
+    #[inline]
+    pub fn get(&self, x: usize, y: usize) -> Option<&S> {
+        if x >= self.width || y >= self.height {
+            return None;
+        }
+
+        Some(&self.buf[y * self.width + x + self.offset])
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self, x: usize, y: usize) -> Option<&mut S> {
+        if x >= self.width || y >= self.height {
+            return None;
+        }
+
+        Some(&mut self.buf[y * self.width + x + self.offset])
+    }
+
+    /// Get the immutable slice to the underlying buffer.
+    #[inline]
+    pub fn buf(&self) -> &[S] {
+        &self.buf[self.offset..]
+    }
+
+    /// Get the mutable slice to the underlying buffer.
+    #[inline]
+    pub fn buf_mut(&mut self) -> &mut [S] {
+        &mut self.buf[self.offset..]
+    }
+
+    #[inline]
+    pub fn as_subgrid(&self) -> SharedSubgrid<S> {
+        SharedSubgrid::from(self)
+    }
+
+    #[inline]
+    pub fn as_subgrid_mut(&mut self) -> MutableSubgrid<S> {
+        MutableSubgrid::from(self)
+    }
+}
+
+/// `[AlignedGrid]` with padding.
+#[derive(Debug)]
+pub struct PaddedGrid<S: Clone> {
+    pub grid: AlignedGrid<S>,
+    padding: usize,
+}
+
+impl<S: Default + Clone> PaddedGrid<S> {
+    /// Create a new buffer.
+    pub fn with_alloc_tracker(
+        width: usize,
+        height: usize,
+        padding: usize,
+        tracker: Option<&AllocTracker>,
+    ) -> Result<Self, crate::Error> {
+        Ok(Self {
+            grid: AlignedGrid::with_alloc_tracker(
+                width + padding * 2,
+                height + padding * 2,
+                tracker,
+            )?,
+            padding,
+        })
+    }
+}
+
+impl<S: Clone> PaddedGrid<S> {
+    #[inline]
+    pub fn width(&self) -> usize {
+        self.grid.width - self.padding * 2
+    }
+
+    #[inline]
+    pub fn height(&self) -> usize {
+        self.grid.height - self.padding * 2
+    }
+
+    #[inline]
+    pub fn padding(&self) -> usize {
+        self.padding
+    }
+
+    #[inline]
+    pub fn buf_padded(&self) -> &[S] {
+        self.grid.buf()
+    }
+
+    #[inline]
+    pub fn buf_padded_mut(&mut self) -> &mut [S] {
+        self.grid.buf_mut()
+    }
+
+    /// Use mirror operator on padding
+    pub fn mirror_edges_padding(&mut self) {
+        let padding = self.padding;
+        let stride = self.grid.width();
+        let height = self.grid.height() - padding * 2;
+
+        // Mirror horizontally.
+        let buf = self.grid.buf_mut();
+        for y in padding..height + padding {
+            for x in 0..padding {
+                buf[y * stride + x] = buf[y * stride + padding * 2 - x - 1].clone();
+                buf[(y + 1) * stride - x - 1] = buf[(y + 1) * stride - padding * 2 + x].clone();
+            }
+        }
+
+        // Mirror vertically.
+        let (out_chunk, in_chunk) = buf.split_at_mut(stride * padding);
+        let in_chunk = &in_chunk[..stride * padding];
+        for (out_row, in_row) in out_chunk
+            .chunks_exact_mut(stride)
+            .zip(in_chunk.chunks_exact(stride).rev())
+        {
+            out_row.clone_from_slice(in_row);
+        }
+
+        let (in_chunk, out_chunk) = buf.split_at_mut(stride * (height + padding));
+        for (out_row, in_row) in out_chunk
+            .chunks_exact_mut(stride)
+            .zip(in_chunk.chunks_exact(stride).rev())
+        {
+            out_row.clone_from_slice(in_row);
         }
     }
 }

--- a/crates/jxl-grid/src/shared_subgrid.rs
+++ b/crates/jxl-grid/src/shared_subgrid.rs
@@ -14,8 +14,8 @@ pub struct SharedSubgrid<'g, V = f32> {
 unsafe impl<'g, V> Send for SharedSubgrid<'g, V> where &'g [V]: Send {}
 unsafe impl<'g, V> Sync for SharedSubgrid<'g, V> where &'g [V]: Sync {}
 
-impl<'g, V> From<&'g crate::SimpleGrid<V>> for SharedSubgrid<'g, V> {
-    fn from(value: &'g crate::SimpleGrid<V>) -> Self {
+impl<'g, V> From<&'g crate::AlignedGrid<V>> for SharedSubgrid<'g, V> {
+    fn from(value: &'g crate::AlignedGrid<V>) -> Self {
         SharedSubgrid::from_buf(value.buf(), value.width(), value.height(), value.width())
     }
 }

--- a/crates/jxl-modular/src/predictor.rs
+++ b/crates/jxl-modular/src/predictor.rs
@@ -1,5 +1,5 @@
 use jxl_bitstream::define_bundle;
-use jxl_grid::CutGrid;
+use jxl_grid::MutableSubgrid;
 
 use crate::Sample;
 
@@ -137,7 +137,7 @@ pub struct PredictorState<'prev, 'a, S: Sample> {
     width: u32,
     prev_row: Vec<i32>,
     curr_row: Vec<i32>,
-    prev_channels_rev: Vec<&'a CutGrid<'prev, S>>,
+    prev_channels_rev: Vec<&'a MutableSubgrid<'prev, S>>,
     self_correcting: Option<SelfCorrectingPredictor>,
     y: u32,
     x: u32,
@@ -179,7 +179,7 @@ impl<'prev, 'a, S: Sample> PredictorState<'prev, 'a, S> {
     pub fn reset(
         &mut self,
         width: u32,
-        prev_channels_rev: &[&'a CutGrid<'prev, S>],
+        prev_channels_rev: &[&'a MutableSubgrid<'prev, S>],
         wp_header: Option<&WpHeader>,
     ) {
         self.self_correcting =

--- a/crates/jxl-modular/src/sample.rs
+++ b/crates/jxl-modular/src/sample.rs
@@ -1,13 +1,13 @@
 use jxl_bitstream::unpack_signed;
-use jxl_grid::CutGrid;
+use jxl_grid::MutableSubgrid;
 
 pub trait Sealed: Copy + Default + Send + Sync {
-    fn try_as_i32_cut_grid_mut<'a, 'g>(
-        grid: &'a mut CutGrid<'g, Self>,
-    ) -> Option<&'a mut CutGrid<'g, i32>>;
-    fn try_as_i16_cut_grid_mut<'a, 'g>(
-        grid: &'a mut CutGrid<'g, Self>,
-    ) -> Option<&'a mut CutGrid<'g, i16>>;
+    fn try_as_mutable_subgrid_i32<'a, 'g>(
+        grid: &'a mut MutableSubgrid<'g, Self>,
+    ) -> Option<&'a mut MutableSubgrid<'g, i32>>;
+    fn try_as_mutable_subgrid_i16<'a, 'g>(
+        grid: &'a mut MutableSubgrid<'g, Self>,
+    ) -> Option<&'a mut MutableSubgrid<'g, i16>>;
 
     fn unpack_signed_u32(value: u32) -> Self;
 
@@ -88,15 +88,15 @@ impl Sample for i16 {
 }
 
 impl Sealed for i32 {
-    fn try_as_i32_cut_grid_mut<'a, 'g>(
-        grid: &'a mut CutGrid<'g, i32>,
-    ) -> Option<&'a mut CutGrid<'g, i32>> {
+    fn try_as_mutable_subgrid_i32<'a, 'g>(
+        grid: &'a mut MutableSubgrid<'g, i32>,
+    ) -> Option<&'a mut MutableSubgrid<'g, i32>> {
         Some(grid)
     }
 
-    fn try_as_i16_cut_grid_mut<'a, 'g>(
-        _: &'a mut CutGrid<'g, i32>,
-    ) -> Option<&'a mut CutGrid<'g, i16>> {
+    fn try_as_mutable_subgrid_i16<'a, 'g>(
+        _: &'a mut MutableSubgrid<'g, i32>,
+    ) -> Option<&'a mut MutableSubgrid<'g, i16>> {
         None
     }
 
@@ -127,15 +127,15 @@ impl Sealed for i32 {
 }
 
 impl Sealed for i16 {
-    fn try_as_i32_cut_grid_mut<'a, 'g>(
-        _: &'a mut CutGrid<'g, i16>,
-    ) -> Option<&'a mut CutGrid<'g, i32>> {
+    fn try_as_mutable_subgrid_i32<'a, 'g>(
+        _: &'a mut MutableSubgrid<'g, i16>,
+    ) -> Option<&'a mut MutableSubgrid<'g, i32>> {
         None
     }
 
-    fn try_as_i16_cut_grid_mut<'a, 'g>(
-        grid: &'a mut CutGrid<'g, i16>,
-    ) -> Option<&'a mut CutGrid<'g, i16>> {
+    fn try_as_mutable_subgrid_i16<'a, 'g>(
+        grid: &'a mut MutableSubgrid<'g, i16>,
+    ) -> Option<&'a mut MutableSubgrid<'g, i16>> {
         Some(grid)
     }
 

--- a/crates/jxl-modular/src/transform.rs
+++ b/crates/jxl-modular/src/transform.rs
@@ -1,5 +1,5 @@
 use jxl_bitstream::{define_bundle, read_bits, Bitstream, Bundle};
-use jxl_grid::{AllocTracker, CutGrid, SimpleGrid};
+use jxl_grid::{AlignedGrid, AllocTracker, MutableSubgrid};
 use jxl_threadpool::JxlThreadPool;
 
 use super::{
@@ -38,13 +38,13 @@ impl TransformInfo {
 
     pub(super) fn prepare_meta_channels<S: Sample>(
         &self,
-        meta_channels: &mut Vec<SimpleGrid<S>>,
+        meta_channels: &mut Vec<AlignedGrid<S>>,
         tracker: Option<&AllocTracker>,
     ) -> Result<()> {
         if let Self::Palette(pal) = self {
             meta_channels.insert(
                 0,
-                SimpleGrid::with_alloc_tracker(
+                AlignedGrid::with_alloc_tracker(
                     pal.nb_colours as usize,
                     pal.num_c as usize,
                     tracker,
@@ -57,7 +57,7 @@ impl TransformInfo {
     pub(super) fn transform_channels<'dest, S: Sample>(
         &self,
         channels: &mut super::ModularChannels,
-        meta_channel_grids: &mut Vec<CutGrid<'dest, S>>,
+        meta_channel_grids: &mut Vec<MutableSubgrid<'dest, S>>,
         grids: &mut Vec<TransformedGrid<'dest, S>>,
     ) -> Result<()> {
         match self {
@@ -213,7 +213,7 @@ impl Palette {
     fn transform_channel_info<'dest, S: Sample>(
         &self,
         channels: &mut super::ModularChannels,
-        meta_channel_grids: &mut Vec<CutGrid<'dest, S>>,
+        meta_channel_grids: &mut Vec<MutableSubgrid<'dest, S>>,
         grids: Option<&mut Vec<TransformedGrid<'dest, S>>>,
     ) -> Result<()> {
         let begin_c = self.begin_c;

--- a/crates/jxl-modular/src/transform/palette.rs
+++ b/crates/jxl-modular/src/transform/palette.rs
@@ -1,4 +1,4 @@
-use jxl_grid::{CutGrid, SharedSubgrid};
+use jxl_grid::{MutableSubgrid, SharedSubgrid};
 
 use crate::{
     predictor::{Predictor, PredictorState},
@@ -27,7 +27,7 @@ impl Palette {
     pub(crate) fn inverse_inner<S: Sample>(
         &self,
         palette: SharedSubgrid<S>,
-        mut targets: Vec<CutGrid<S>>,
+        mut targets: Vec<MutableSubgrid<S>>,
         bit_depth: u32,
     ) {
         let nb_deltas = self.nb_deltas as i32;
@@ -144,7 +144,7 @@ impl Palette {
 }
 
 #[inline(never)]
-fn inverse_simple<S: Sample>(palette: SharedSubgrid<S>, targets: Vec<CutGrid<S>>) {
+fn inverse_simple<S: Sample>(palette: SharedSubgrid<S>, targets: Vec<MutableSubgrid<S>>) {
     let height = targets[0].height();
     let channels = targets.len();
     assert_eq!(channels, palette.height());

--- a/crates/jxl-modular/src/transform/rct.rs
+++ b/crates/jxl-modular/src/transform/rct.rs
@@ -4,7 +4,7 @@ use std::arch::is_aarch64_feature_detected;
 use std::arch::is_x86_feature_detected;
 use std::num::Wrapping;
 
-use jxl_grid::CutGrid;
+use jxl_grid::MutableSubgrid;
 use jxl_threadpool::JxlThreadPool;
 
 use crate::Sample;
@@ -14,10 +14,10 @@ type UnsafeFnRow<S> = unsafe fn(&mut [&mut [S]; 3]);
 
 pub fn inverse_rct<S: Sample, const TYPE: u32>(
     permutation: u32,
-    mut grids: [&mut CutGrid<S>; 3],
+    mut grids: [&mut MutableSubgrid<S>; 3],
     pool: &JxlThreadPool,
 ) {
-    let grid16 = grids.each_mut().map(|g| S::try_as_i16_cut_grid_mut(g));
+    let grid16 = grids.each_mut().map(|g| S::try_as_mutable_subgrid_i16(g));
     if let [Some(a), Some(b), Some(c)] = grid16 {
         let grids = [a, b, c];
 
@@ -51,7 +51,7 @@ pub fn inverse_rct<S: Sample, const TYPE: u32>(
         return;
     }
 
-    let grid32 = grids.each_mut().map(|g| S::try_as_i32_cut_grid_mut(g));
+    let grid32 = grids.each_mut().map(|g| S::try_as_mutable_subgrid_i32(g));
     if let [Some(a), Some(b), Some(c)] = grid32 {
         let grids = [a, b, c];
 
@@ -88,7 +88,7 @@ pub fn inverse_rct<S: Sample, const TYPE: u32>(
 #[inline]
 fn run_rows<S: Sample>(
     permutation: u32,
-    grids: [&mut CutGrid<S>; 3],
+    grids: [&mut MutableSubgrid<S>; 3],
     f: FnRow<S>,
     pool: &JxlThreadPool,
 ) {
@@ -99,12 +99,12 @@ fn run_rows<S: Sample>(
 #[inline(never)]
 unsafe fn run_rows_unsafe<S: Sample>(
     permutation: u32,
-    grids: [&mut CutGrid<S>; 3],
+    grids: [&mut MutableSubgrid<S>; 3],
     f: UnsafeFnRow<S>,
     pool: &JxlThreadPool,
 ) {
     struct RctJob<'g, S: Sample> {
-        grids: [CutGrid<'g, S>; 3],
+        grids: [MutableSubgrid<'g, S>; 3],
     }
 
     let width = grids[0].width();

--- a/crates/jxl-modular/src/transform/squeeze.rs
+++ b/crates/jxl-modular/src/transform/squeeze.rs
@@ -4,24 +4,24 @@ use std::arch::is_aarch64_feature_detected;
 use std::arch::is_x86_feature_detected;
 use std::num::Wrapping;
 
-use jxl_grid::CutGrid;
+use jxl_grid::MutableSubgrid;
 
 use crate::Sample;
 
-pub fn inverse_h<S: Sample>(merged: &mut CutGrid<'_, S>) {
-    if let Some(merged) = S::try_as_i16_cut_grid_mut(merged) {
+pub fn inverse_h<S: Sample>(merged: &mut MutableSubgrid<'_, S>) {
+    if let Some(merged) = S::try_as_mutable_subgrid_i16(merged) {
         inverse_h_i16(merged)
-    } else if let Some(merged) = S::try_as_i32_cut_grid_mut(merged) {
+    } else if let Some(merged) = S::try_as_mutable_subgrid_i32(merged) {
         inverse_h_i32(merged)
     }
 }
 
-fn inverse_h_i32(merged: &mut CutGrid<i32>) {
+fn inverse_h_i32(merged: &mut MutableSubgrid<i32>) {
     inverse_h_i32_base(merged)
 }
 
 #[allow(unreachable_code)]
-fn inverse_h_i16(merged: &mut CutGrid<i16>) {
+fn inverse_h_i16(merged: &mut MutableSubgrid<i16>) {
     #[cfg(target_arch = "x86_64")]
     if is_x86_feature_detected!("sse4.1") && is_x86_feature_detected!("sse2") {
         if is_x86_feature_detected!("avx2") {
@@ -56,7 +56,7 @@ fn inverse_h_i16(merged: &mut CutGrid<i16>) {
     inverse_h_i16_base(merged)
 }
 
-fn inverse_h_i32_base(merged: &mut CutGrid<'_, i32>) {
+fn inverse_h_i32_base(merged: &mut MutableSubgrid<'_, i32>) {
     let height = merged.height();
     let width = merged.width();
     let mut scratch = vec![0i32; width];
@@ -88,7 +88,7 @@ fn inverse_h_i32_base(merged: &mut CutGrid<'_, i32>) {
 }
 
 #[inline(never)]
-fn inverse_h_i16_base(merged: &mut CutGrid<'_, i16>) {
+fn inverse_h_i16_base(merged: &mut MutableSubgrid<'_, i16>) {
     let height = merged.height();
     let width = merged.width();
     let mut scratch = vec![0i16; width];
@@ -205,7 +205,7 @@ unsafe fn transpose_i16x8(vs: [std::arch::x86_64::__m128i; 8]) -> [std::arch::x8
 #[target_feature(enable = "avx2")]
 #[target_feature(enable = "sse4.1")]
 #[target_feature(enable = "sse2")]
-unsafe fn inverse_h_i16_x86_64_avx2(merged: &mut CutGrid<'_, i16>) {
+unsafe fn inverse_h_i16_x86_64_avx2(merged: &mut MutableSubgrid<'_, i16>) {
     use std::arch::x86_64::*;
     use std::mem::MaybeUninit;
 
@@ -354,7 +354,7 @@ unsafe fn inverse_h_i16_x86_64_avx2(merged: &mut CutGrid<'_, i16>) {
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "sse2")]
 #[target_feature(enable = "sse4.1")]
-unsafe fn inverse_h_i16_x86_64_sse41(merged: &mut CutGrid<'_, i16>) {
+unsafe fn inverse_h_i16_x86_64_sse41(merged: &mut MutableSubgrid<'_, i16>) {
     use std::arch::x86_64::*;
     use std::mem::MaybeUninit;
 
@@ -463,7 +463,7 @@ unsafe fn inverse_h_i16_x86_64_sse41(merged: &mut CutGrid<'_, i16>) {
 
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
-unsafe fn inverse_h_i16_aarch64_neon(merged: &mut CutGrid<'_, i16>) {
+unsafe fn inverse_h_i16_aarch64_neon(merged: &mut MutableSubgrid<'_, i16>) {
     use std::arch::aarch64::*;
     use std::mem::MaybeUninit;
 
@@ -610,7 +610,7 @@ unsafe fn inverse_h_i16_aarch64_neon(merged: &mut CutGrid<'_, i16>) {
 }
 
 #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
-unsafe fn inverse_h_i16_wasm32_simd128(merged: &mut CutGrid<'_, i16>) {
+unsafe fn inverse_h_i16_wasm32_simd128(merged: &mut MutableSubgrid<'_, i16>) {
     use std::arch::wasm32::*;
     use std::mem::MaybeUninit;
 
@@ -752,20 +752,20 @@ unsafe fn inverse_h_i16_wasm32_simd128(merged: &mut CutGrid<'_, i16>) {
     }
 }
 
-pub fn inverse_v<S: Sample>(merged: &mut CutGrid<'_, S>) {
-    if let Some(merged) = S::try_as_i16_cut_grid_mut(merged) {
+pub fn inverse_v<S: Sample>(merged: &mut MutableSubgrid<'_, S>) {
+    if let Some(merged) = S::try_as_mutable_subgrid_i16(merged) {
         inverse_v_i16(merged)
-    } else if let Some(merged) = S::try_as_i32_cut_grid_mut(merged) {
+    } else if let Some(merged) = S::try_as_mutable_subgrid_i32(merged) {
         inverse_v_i32(merged)
     }
 }
 
-fn inverse_v_i32(merged: &mut CutGrid<i32>) {
+fn inverse_v_i32(merged: &mut MutableSubgrid<i32>) {
     inverse_v_i32_base(merged)
 }
 
 #[allow(unreachable_code)]
-fn inverse_v_i16(merged: &mut CutGrid<i16>) {
+fn inverse_v_i16(merged: &mut MutableSubgrid<i16>) {
     #[cfg(target_arch = "x86_64")]
     if is_x86_feature_detected!("sse4.1") && is_x86_feature_detected!("sse2") {
         if is_x86_feature_detected!("avx2") {
@@ -800,7 +800,7 @@ fn inverse_v_i16(merged: &mut CutGrid<i16>) {
     inverse_v_i16_base(merged)
 }
 
-fn inverse_v_i32_base(merged: &mut CutGrid<'_, i32>) {
+fn inverse_v_i32_base(merged: &mut MutableSubgrid<'_, i32>) {
     let width = merged.width();
     let height = merged.height();
     let mut scratch = vec![0i32; height];
@@ -831,7 +831,7 @@ fn inverse_v_i32_base(merged: &mut CutGrid<'_, i32>) {
 }
 
 #[inline(never)]
-fn inverse_v_i16_base(merged: &mut CutGrid<'_, i16>) {
+fn inverse_v_i16_base(merged: &mut MutableSubgrid<'_, i16>) {
     let width = merged.width();
     let height = merged.height();
     let mut scratch = vec![0i16; height];
@@ -865,7 +865,7 @@ fn inverse_v_i16_base(merged: &mut CutGrid<'_, i16>) {
 #[target_feature(enable = "avx2")]
 #[target_feature(enable = "sse4.1")]
 #[target_feature(enable = "sse2")]
-unsafe fn inverse_v_i16_x86_64_avx2(merged: &mut CutGrid<'_, i16>) {
+unsafe fn inverse_v_i16_x86_64_avx2(merged: &mut MutableSubgrid<'_, i16>) {
     use std::arch::x86_64::*;
     use std::mem::MaybeUninit;
 
@@ -927,7 +927,7 @@ unsafe fn inverse_v_i16_x86_64_avx2(merged: &mut CutGrid<'_, i16>) {
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "sse4.1")]
 #[target_feature(enable = "sse2")]
-unsafe fn inverse_v_i16_x86_64_sse41(merged: &mut CutGrid<'_, i16>) {
+unsafe fn inverse_v_i16_x86_64_sse41(merged: &mut MutableSubgrid<'_, i16>) {
     use std::arch::x86_64::*;
     use std::mem::MaybeUninit;
 
@@ -986,7 +986,7 @@ unsafe fn inverse_v_i16_x86_64_sse41(merged: &mut CutGrid<'_, i16>) {
 
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
-unsafe fn inverse_v_i16_aarch64_neon(merged: &mut CutGrid<'_, i16>) {
+unsafe fn inverse_v_i16_aarch64_neon(merged: &mut MutableSubgrid<'_, i16>) {
     use std::arch::aarch64::*;
     use std::mem::MaybeUninit;
 
@@ -1044,7 +1044,7 @@ unsafe fn inverse_v_i16_aarch64_neon(merged: &mut CutGrid<'_, i16>) {
 }
 
 #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
-unsafe fn inverse_v_i16_wasm32_simd128(merged: &mut CutGrid<'_, i16>) {
+unsafe fn inverse_v_i16_wasm32_simd128(merged: &mut MutableSubgrid<'_, i16>) {
     use std::arch::wasm32::*;
     use std::mem::MaybeUninit;
 

--- a/crates/jxl-oxide/src/fb.rs
+++ b/crates/jxl-oxide/src/fb.rs
@@ -1,4 +1,4 @@
-use jxl_grid::SimpleGrid;
+use jxl_grid::AlignedGrid;
 
 /// Frame buffer representing a decoded image.
 #[derive(Debug, Clone)]
@@ -24,7 +24,7 @@ impl FrameBuffer {
 
     /// For internal use only.
     #[doc(hidden)]
-    pub fn from_grids(grids: &[&SimpleGrid<f32>], orientation: u32) -> Self {
+    pub fn from_grids(grids: &[&AlignedGrid<f32>], orientation: u32) -> Self {
         let channels = grids.len();
         if channels == 0 {
             panic!("framebuffer should have channels");

--- a/crates/jxl-oxide/src/lib.rs
+++ b/crates/jxl-oxide/src/lib.rs
@@ -157,7 +157,7 @@ pub use jxl_color::{
 };
 pub use jxl_frame::header as frame;
 pub use jxl_frame::{Frame, FrameHeader};
-pub use jxl_grid::{AllocTracker, SimpleGrid};
+pub use jxl_grid::{AlignedGrid, AllocTracker};
 pub use jxl_image as image;
 pub use jxl_image::{ExtraChannelType, ImageHeader};
 pub use jxl_threadpool::JxlThreadPool;
@@ -761,8 +761,8 @@ impl JxlImage {
 
     fn process_render(
         &self,
-        mut grids: Vec<SimpleGrid<f32>>,
-    ) -> Result<(Vec<SimpleGrid<f32>>, Vec<ExtraChannel>)> {
+        mut grids: Vec<AlignedGrid<f32>>,
+    ) -> Result<(Vec<AlignedGrid<f32>>, Vec<ExtraChannel>)> {
         let pixel_format = self.pixel_format();
         let color_channels = if pixel_format.is_grayscale() { 1 } else { 3 };
         let mut color_channels: Vec<_> = grids.drain(..color_channels).collect();
@@ -884,7 +884,7 @@ pub struct Render {
     name: Name,
     duration: u32,
     orientation: u32,
-    color_channels: Vec<SimpleGrid<f32>>,
+    color_channels: Vec<AlignedGrid<f32>>,
     extra_channels: Vec<ExtraChannel>,
 }
 
@@ -966,7 +966,7 @@ impl Render {
     ///
     /// Orientation is not applied.
     #[inline]
-    pub fn color_channels(&self) -> &[SimpleGrid<f32>] {
+    pub fn color_channels(&self) -> &[AlignedGrid<f32>] {
         &self.color_channels
     }
 
@@ -974,7 +974,7 @@ impl Render {
     ///
     /// Orientation is not applied.
     #[inline]
-    pub fn color_channels_mut(&mut self) -> &mut [SimpleGrid<f32>] {
+    pub fn color_channels_mut(&mut self) -> &mut [AlignedGrid<f32>] {
         &mut self.color_channels
     }
 
@@ -1043,7 +1043,7 @@ pub struct ImageStream<'r> {
     orientation: u32,
     width: u32,
     height: u32,
-    grids: Vec<&'r SimpleGrid<f32>>,
+    grids: Vec<&'r AlignedGrid<f32>>,
     y: u32,
     x: u32,
     c: u32,
@@ -1118,7 +1118,7 @@ impl ImageStream<'_> {
 pub struct ExtraChannel {
     ty: ExtraChannelType,
     name: Name,
-    grid: SimpleGrid<f32>,
+    grid: AlignedGrid<f32>,
 }
 
 impl ExtraChannel {
@@ -1136,13 +1136,13 @@ impl ExtraChannel {
 
     /// Returns the sample grid of the channel.
     #[inline]
-    pub fn grid(&self) -> &SimpleGrid<f32> {
+    pub fn grid(&self) -> &AlignedGrid<f32> {
         &self.grid
     }
 
     /// Returns the mutable sample grid of the channel.
     #[inline]
-    pub fn grid_mut(&mut self) -> &mut SimpleGrid<f32> {
+    pub fn grid_mut(&mut self) -> &mut AlignedGrid<f32> {
         &mut self.grid
     }
 

--- a/crates/jxl-render/src/features/noise.rs
+++ b/crates/jxl-render/src/features/noise.rs
@@ -1,7 +1,7 @@
 use std::num::Wrapping;
 
 use jxl_frame::{data::NoiseParameters, FrameHeader};
-use jxl_grid::{AllocTracker, PaddedGrid, SimpleGrid};
+use jxl_grid::{AlignedGrid, AllocTracker, PaddedGrid};
 
 use crate::{ImageWithRegion, Region, Result};
 
@@ -88,7 +88,7 @@ fn init_noise(
     invisible_frames: usize,
     header: &FrameHeader,
     tracker: Option<&AllocTracker>,
-) -> Result<[SimpleGrid<f32>; 3]> {
+) -> Result<[AlignedGrid<f32>; 3]> {
     let seed0 = rng_seed0(visible_frames, invisible_frames);
 
     // We use header.width and header.height because
@@ -122,10 +122,10 @@ fn init_noise(
         channel.mirror_edges_padding();
     }
 
-    let mut convolved: [SimpleGrid<f32>; 3] = [
-        SimpleGrid::with_alloc_tracker(width, height, tracker)?,
-        SimpleGrid::with_alloc_tracker(width, height, tracker)?,
-        SimpleGrid::with_alloc_tracker(width, height, tracker)?,
+    let mut convolved: [AlignedGrid<f32>; 3] = [
+        AlignedGrid::with_alloc_tracker(width, height, tracker)?,
+        AlignedGrid::with_alloc_tracker(width, height, tracker)?,
+        AlignedGrid::with_alloc_tracker(width, height, tracker)?,
     ];
 
     let mut laplacian = [[0.16f32; 5]; 5];

--- a/crates/jxl-render/src/features/spot_colors.rs
+++ b/crates/jxl-render/src/features/spot_colors.rs
@@ -1,10 +1,10 @@
-use jxl_grid::SimpleGrid;
+use jxl_grid::AlignedGrid;
 use jxl_image::ExtraChannelType;
 
 /// Renders a spot color channel onto color_channels
 pub fn render_spot_color(
-    color_channels: &mut [SimpleGrid<f32>],
-    ec_grid: &SimpleGrid<f32>,
+    color_channels: &mut [AlignedGrid<f32>],
+    ec_grid: &AlignedGrid<f32>,
     ec_ty: &ExtraChannelType,
 ) -> crate::Result<()> {
     let ExtraChannelType::SpotColour {

--- a/crates/jxl-render/src/features/upsampling.rs
+++ b/crates/jxl-render/src/features/upsampling.rs
@@ -1,8 +1,8 @@
 use jxl_frame::FrameHeader;
-use jxl_grid::{PaddedGrid, SimpleGrid};
+use jxl_grid::{AlignedGrid, PaddedGrid};
 
 pub fn upsample(
-    grid: &mut SimpleGrid<f32>,
+    grid: &mut AlignedGrid<f32>,
     image_header: &jxl_image::ImageHeader,
     frame_header: &FrameHeader,
     channel_idx: usize,
@@ -51,7 +51,7 @@ pub fn upsample(
 }
 
 fn upsample_inner<const K: usize, const NW: usize>(
-    grid: &mut SimpleGrid<f32>,
+    grid: &mut AlignedGrid<f32>,
     weights: &[f32; NW],
 ) -> crate::Result<()> {
     assert!((K == 2 && NW == 15) || (K == 4 && NW == 55) || (K == 8 && NW == 210));
@@ -101,7 +101,7 @@ fn upsample_inner<const K: usize, const NW: usize>(
         }
     }
 
-    *grid = SimpleGrid::with_alloc_tracker(frame_width, frame_height, tracker.as_ref())?;
+    *grid = AlignedGrid::with_alloc_tracker(frame_width, frame_height, tracker.as_ref())?;
     let padded_buf = padded.buf_padded();
     let grid_buf = grid.buf_mut();
     for y in 0..frame_height {

--- a/crates/jxl-render/src/filter/epf.rs
+++ b/crates/jxl-render/src/filter/epf.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use jxl_frame::{data::LfGroup, filter::EpfParams, FrameHeader};
-use jxl_grid::SimpleGrid;
+use jxl_grid::AlignedGrid;
 use jxl_modular::Sample;
 use jxl_threadpool::JxlThreadPool;
 
@@ -9,7 +9,7 @@ use crate::{util, ImageWithRegion, Region};
 
 pub fn apply_epf<S: Sample>(
     fb: &mut ImageWithRegion,
-    fb_scratch: &mut [SimpleGrid<f32>; 3],
+    fb_scratch: &mut [AlignedGrid<f32>; 3],
     lf_groups: &HashMap<u32, LfGroup<S>>,
     frame_header: &FrameHeader,
     epf_params: &EpfParams,
@@ -24,7 +24,7 @@ pub fn apply_epf<S: Sample>(
     let fb = <&mut [_; 3]>::try_from(fb.buffer_mut()).unwrap();
 
     let num_lf_groups = frame_header.num_lf_groups() as usize;
-    let mut sigma_grid_map = vec![None::<&SimpleGrid<f32>>; num_lf_groups];
+    let mut sigma_grid_map = vec![None::<&AlignedGrid<f32>>; num_lf_groups];
 
     for (&lf_group_idx, lf_group) in lf_groups {
         if let Some(hf_meta) = &lf_group.hf_meta {
@@ -99,10 +99,10 @@ pub(super) struct EpfRow<'buf, 'epf> {
 
 #[allow(clippy::too_many_arguments)]
 pub(super) unsafe fn run_epf_rows<'buf>(
-    input: &'buf [SimpleGrid<f32>; 3],
-    output: &'buf mut [SimpleGrid<f32>; 3],
+    input: &'buf [AlignedGrid<f32>; 3],
+    output: &'buf mut [AlignedGrid<f32>; 3],
     frame_header: &FrameHeader,
-    sigma_grid_map: &[Option<&SimpleGrid<f32>>],
+    sigma_grid_map: &[Option<&AlignedGrid<f32>>],
     region: Region,
     epf_params: &EpfParams,
     pool: &JxlThreadPool,

--- a/crates/jxl-render/src/filter/gabor.rs
+++ b/crates/jxl-render/src/filter/gabor.rs
@@ -1,5 +1,5 @@
 use jxl_frame::FrameHeader;
-use jxl_grid::SimpleGrid;
+use jxl_grid::AlignedGrid;
 use jxl_threadpool::JxlThreadPool;
 
 use crate::{ImageWithRegion, Region};
@@ -8,7 +8,7 @@ use super::impls::generic::gabor::gabor_row_edge;
 
 pub fn apply_gabor_like(
     fb: &mut ImageWithRegion,
-    fb_scratch: &mut [SimpleGrid<f32>; 3],
+    fb_scratch: &mut [AlignedGrid<f32>; 3],
     frame_header: &FrameHeader,
     weights: [[f32; 2]; 3],
     pool: &jxl_threadpool::JxlThreadPool,
@@ -29,8 +29,8 @@ pub(super) struct GaborRow<'buf> {
 }
 
 pub(super) fn run_gabor_rows<'buf>(
-    input: &'buf SimpleGrid<f32>,
-    output: &'buf mut SimpleGrid<f32>,
+    input: &'buf AlignedGrid<f32>,
+    output: &'buf mut AlignedGrid<f32>,
     frame_header: &FrameHeader,
     region: Region,
     weights: [f32; 2],
@@ -51,8 +51,8 @@ pub(super) fn run_gabor_rows<'buf>(
 }
 
 pub(super) unsafe fn run_gabor_rows_unsafe<'buf>(
-    input: &'buf SimpleGrid<f32>,
-    output: &'buf mut SimpleGrid<f32>,
+    input: &'buf AlignedGrid<f32>,
+    output: &'buf mut AlignedGrid<f32>,
     frame_header: &FrameHeader,
     region: Region,
     weights: [f32; 2],

--- a/crates/jxl-render/src/filter/impls/aarch64.rs
+++ b/crates/jxl-render/src/filter/impls/aarch64.rs
@@ -1,7 +1,7 @@
 use std::arch::is_aarch64_feature_detected;
 
 use jxl_frame::{filter::EpfParams, FrameHeader};
-use jxl_grid::SimpleGrid;
+use jxl_grid::AlignedGrid;
 use jxl_threadpool::JxlThreadPool;
 
 use crate::filter::epf::run_epf_rows;
@@ -14,10 +14,10 @@ mod gabor;
 use gabor::run_gabor_row_aarch64_neon;
 
 pub fn epf<const STEP: usize>(
-    input: &[SimpleGrid<f32>; 3],
-    output: &mut [SimpleGrid<f32>; 3],
+    input: &[AlignedGrid<f32>; 3],
+    output: &mut [AlignedGrid<f32>; 3],
     frame_header: &FrameHeader,
-    sigma_grid_map: &[Option<&SimpleGrid<f32>>],
+    sigma_grid_map: &[Option<&AlignedGrid<f32>>],
     region: Region,
     epf_params: &EpfParams,
     pool: &JxlThreadPool,
@@ -56,8 +56,8 @@ pub fn epf<const STEP: usize>(
 }
 
 pub fn apply_gabor_like(
-    fb: &[SimpleGrid<f32>; 3],
-    fb_scratch: &mut [SimpleGrid<f32>; 3],
+    fb: &[AlignedGrid<f32>; 3],
+    fb_scratch: &mut [AlignedGrid<f32>; 3],
     frame_header: &FrameHeader,
     region: Region,
     weights: [[f32; 2]; 3],

--- a/crates/jxl-render/src/filter/impls/generic.rs
+++ b/crates/jxl-render/src/filter/impls/generic.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use jxl_frame::{filter::EpfParams, FrameHeader};
-use jxl_grid::SimpleGrid;
+use jxl_grid::AlignedGrid;
 use jxl_threadpool::JxlThreadPool;
 
 use crate::{
@@ -13,10 +13,10 @@ pub(crate) mod epf;
 pub(crate) mod gabor;
 
 pub fn epf<const STEP: usize>(
-    input: &[SimpleGrid<f32>; 3],
-    output: &mut [SimpleGrid<f32>; 3],
+    input: &[AlignedGrid<f32>; 3],
+    output: &mut [AlignedGrid<f32>; 3],
     frame_header: &FrameHeader,
-    sigma_grid_map: &[Option<&SimpleGrid<f32>>],
+    sigma_grid_map: &[Option<&AlignedGrid<f32>>],
     region: Region,
     epf_params: &EpfParams,
     pool: &JxlThreadPool,
@@ -37,8 +37,8 @@ pub fn epf<const STEP: usize>(
 }
 
 pub fn apply_gabor_like(
-    fb: &[SimpleGrid<f32>; 3],
-    fb_scratch: &mut [SimpleGrid<f32>; 3],
+    fb: &[AlignedGrid<f32>; 3],
+    fb_scratch: &mut [AlignedGrid<f32>; 3],
     frame_header: &FrameHeader,
     region: Region,
     weights: [[f32; 2]; 3],

--- a/crates/jxl-render/src/filter/impls/wasm32.rs
+++ b/crates/jxl-render/src/filter/impls/wasm32.rs
@@ -1,5 +1,5 @@
 use jxl_frame::{filter::EpfParams, FrameHeader};
-use jxl_grid::SimpleGrid;
+use jxl_grid::AlignedGrid;
 use jxl_threadpool::JxlThreadPool;
 
 use crate::filter::epf::run_epf_rows;
@@ -8,10 +8,10 @@ use crate::Region;
 mod epf;
 
 pub fn epf<const STEP: usize>(
-    input: &[SimpleGrid<f32>; 3],
-    output: &mut [SimpleGrid<f32>; 3],
+    input: &[AlignedGrid<f32>; 3],
+    output: &mut [AlignedGrid<f32>; 3],
     frame_header: &FrameHeader,
-    sigma_grid_map: &[Option<&SimpleGrid<f32>>],
+    sigma_grid_map: &[Option<&AlignedGrid<f32>>],
     region: Region,
     epf_params: &EpfParams,
     pool: &JxlThreadPool,

--- a/crates/jxl-render/src/filter/impls/x86_64.rs
+++ b/crates/jxl-render/src/filter/impls/x86_64.rs
@@ -1,5 +1,5 @@
 use jxl_frame::{filter::EpfParams, FrameHeader};
-use jxl_grid::SimpleGrid;
+use jxl_grid::AlignedGrid;
 use jxl_threadpool::JxlThreadPool;
 
 use crate::{
@@ -14,10 +14,10 @@ mod epf_sse41;
 mod gabor_avx2;
 
 pub fn epf<const STEP: usize>(
-    input: &[SimpleGrid<f32>; 3],
-    output: &mut [SimpleGrid<f32>; 3],
+    input: &[AlignedGrid<f32>; 3],
+    output: &mut [AlignedGrid<f32>; 3],
     frame_header: &FrameHeader,
-    sigma_grid_map: &[Option<&SimpleGrid<f32>>],
+    sigma_grid_map: &[Option<&AlignedGrid<f32>>],
     region: Region,
     epf_params: &EpfParams,
     pool: &JxlThreadPool,
@@ -55,8 +55,8 @@ pub fn epf<const STEP: usize>(
 }
 
 pub fn apply_gabor_like(
-    fb: &[SimpleGrid<f32>; 3],
-    fb_scratch: &mut [SimpleGrid<f32>; 3],
+    fb: &[AlignedGrid<f32>; 3],
+    fb_scratch: &mut [AlignedGrid<f32>; 3],
     frame_header: &FrameHeader,
     region: Region,
     weights: [[f32; 2]; 3],

--- a/crates/jxl-render/src/filter/ycbcr.rs
+++ b/crates/jxl-render/src/filter/ycbcr.rs
@@ -1,6 +1,6 @@
-use jxl_grid::SimpleGrid;
+use jxl_grid::AlignedGrid;
 
-pub fn apply_jpeg_upsampling(grids_cbycr: [&mut SimpleGrid<f32>; 3], jpeg_upsampling: [u32; 3]) {
+pub fn apply_jpeg_upsampling(grids_cbycr: [&mut AlignedGrid<f32>; 3], jpeg_upsampling: [u32; 3]) {
     fn interpolate(left: f32, center: f32, right: f32) -> (f32, f32) {
         (0.25 * left + 0.75 * center, 0.75 * center + 0.25 * right)
     }

--- a/crates/jxl-render/src/modular.rs
+++ b/crates/jxl-render/src/modular.rs
@@ -1,5 +1,5 @@
 use jxl_frame::{data::GlobalModular, FrameHeader};
-use jxl_grid::SimpleGrid;
+use jxl_grid::AlignedGrid;
 use jxl_image::BitDepth;
 use jxl_modular::{image::TransformedModularSubimage, ChannelShift, Sample};
 
@@ -210,8 +210,8 @@ pub fn compute_modular_region<S: Sample>(
 }
 
 pub fn copy_modular_groups<S: Sample>(
-    g: &SimpleGrid<S>,
-    buffer: &mut SimpleGrid<f32>,
+    g: &AlignedGrid<S>,
+    buffer: &mut AlignedGrid<f32>,
     region: Region,
     bit_depth: BitDepth,
     xyb_encoded: bool,

--- a/crates/jxl-render/src/render.rs
+++ b/crates/jxl-render/src/render.rs
@@ -4,7 +4,7 @@ use jxl_frame::{
     header::Encoding,
     FrameHeader,
 };
-use jxl_grid::SimpleGrid;
+use jxl_grid::AlignedGrid;
 use jxl_image::ImageHeader;
 use jxl_modular::Sample;
 use jxl_threadpool::JxlThreadPool;
@@ -82,9 +82,9 @@ pub(crate) fn render_frame<S: Sample>(
             let width = fb.region().width as usize;
             let height = fb.region().height as usize;
             scratch_buffer = Some([
-                SimpleGrid::with_alloc_tracker(width, height, tracker)?,
-                SimpleGrid::with_alloc_tracker(width, height, tracker)?,
-                SimpleGrid::with_alloc_tracker(width, height, tracker)?,
+                AlignedGrid::with_alloc_tracker(width, height, tracker)?,
+                AlignedGrid::with_alloc_tracker(width, height, tracker)?,
+                AlignedGrid::with_alloc_tracker(width, height, tracker)?,
             ]);
         }
         let fb_scratch = scratch_buffer.as_mut().unwrap();
@@ -96,9 +96,9 @@ pub(crate) fn render_frame<S: Sample>(
             let width = fb.region().width as usize;
             let height = fb.region().height as usize;
             scratch_buffer = Some([
-                SimpleGrid::with_alloc_tracker(width, height, tracker)?,
-                SimpleGrid::with_alloc_tracker(width, height, tracker)?,
-                SimpleGrid::with_alloc_tracker(width, height, tracker)?,
+                AlignedGrid::with_alloc_tracker(width, height, tracker)?,
+                AlignedGrid::with_alloc_tracker(width, height, tracker)?,
+                AlignedGrid::with_alloc_tracker(width, height, tracker)?,
             ]);
         }
         let fb_scratch = scratch_buffer.as_mut().unwrap();
@@ -212,7 +212,7 @@ fn append_extra_channels<S: Sample>(
 
         let width = region.width as usize;
         let height = region.height as usize;
-        let mut out = SimpleGrid::with_alloc_tracker(width, height, tracker)?;
+        let mut out = AlignedGrid::with_alloc_tracker(width, height, tracker)?;
         modular::copy_modular_groups(&g, &mut out, region, bit_depth, false);
         features::upsample(&mut out, image_header, frame_header, idx + 3)?;
 

--- a/crates/jxl-render/src/vardct/aarch64/transform.rs
+++ b/crates/jxl-render/src/vardct/aarch64/transform.rs
@@ -1,7 +1,7 @@
 use std::arch::aarch64::*;
 use std::arch::is_aarch64_feature_detected;
 
-use jxl_grid::{CutGrid, SharedSubgrid};
+use jxl_grid::{MutableSubgrid, SharedSubgrid};
 use jxl_modular::ChannelShift;
 use jxl_vardct::{BlockInfo, TransformType};
 
@@ -10,7 +10,7 @@ use crate::vardct::{dct_common::DctDirection, transform_common::transform_varblo
 use super::generic;
 
 #[target_feature(enable = "neon")]
-unsafe fn transform_dct4_aarch64_neon(coeff: &mut CutGrid<'_>) {
+unsafe fn transform_dct4_aarch64_neon(coeff: &mut MutableSubgrid<'_>) {
     generic::aux_idct2_in_place_2(coeff);
 
     let mut scratch_0 = [vdupq_n_f32(0.0); 4];
@@ -49,7 +49,7 @@ unsafe fn transform_dct4_aarch64_neon(coeff: &mut CutGrid<'_>) {
 }
 
 #[target_feature(enable = "neon")]
-unsafe fn transform_dct4x8_aarch64_neon<const TR: bool>(coeff: &mut CutGrid<'_>) {
+unsafe fn transform_dct4x8_aarch64_neon<const TR: bool>(coeff: &mut MutableSubgrid<'_>) {
     let coeff0 = coeff.get(0, 0);
     let coeff1 = coeff.get(0, 1);
     *coeff.get_mut(0, 0) = coeff0 + coeff1;
@@ -141,12 +141,12 @@ unsafe fn transform_dct4x8_aarch64_neon<const TR: bool>(coeff: &mut CutGrid<'_>)
 }
 
 #[target_feature(enable = "neon")]
-unsafe fn transform_dct_aarch64_neon(coeff: &mut CutGrid<'_>) {
+unsafe fn transform_dct_aarch64_neon(coeff: &mut MutableSubgrid<'_>) {
     super::dct::dct_2d_aarch64_neon(coeff, DctDirection::Inverse);
 }
 
 #[target_feature(enable = "neon")]
-unsafe fn transform_aarch64_neon(coeff: &mut CutGrid<'_>, dct_select: TransformType) {
+unsafe fn transform_aarch64_neon(coeff: &mut MutableSubgrid<'_>, dct_select: TransformType) {
     use TransformType::*;
 
     match dct_select {
@@ -166,7 +166,7 @@ unsafe fn transform_aarch64_neon(coeff: &mut CutGrid<'_>, dct_select: TransformT
 #[target_feature(enable = "neon")]
 unsafe fn transform_varblocks_aarch64_neon(
     lf: &[SharedSubgrid<f32>; 3],
-    coeff_out: &mut [CutGrid<'_, f32>; 3],
+    coeff_out: &mut [MutableSubgrid<'_, f32>; 3],
     shifts_cbycr: [ChannelShift; 3],
     block_info: &SharedSubgrid<BlockInfo>,
 ) {
@@ -183,7 +183,7 @@ unsafe fn transform_varblocks_aarch64_neon(
 #[inline]
 pub fn transform_varblocks(
     lf: &[SharedSubgrid<f32>; 3],
-    coeff_out: &mut [CutGrid<'_, f32>; 3],
+    coeff_out: &mut [MutableSubgrid<'_, f32>; 3],
     shifts_cbycr: [ChannelShift; 3],
     block_info: &SharedSubgrid<BlockInfo>,
 ) {

--- a/crates/jxl-render/src/vardct/generic/dct.rs
+++ b/crates/jxl-render/src/vardct/generic/dct.rs
@@ -1,8 +1,8 @@
-use jxl_grid::CutGrid;
+use jxl_grid::MutableSubgrid;
 
 use super::super::dct_common::{self, DctDirection};
 
-pub fn dct_2d(io: &mut CutGrid<'_>, direction: DctDirection) {
+pub fn dct_2d(io: &mut MutableSubgrid<'_>, direction: DctDirection) {
     let width = io.width();
     let height = io.height();
     if width * height <= 1 {

--- a/crates/jxl-render/src/vardct/generic/mod.rs
+++ b/crates/jxl-render/src/vardct/generic/mod.rs
@@ -1,4 +1,4 @@
-use jxl_grid::{AllocTracker, SimpleGrid};
+use jxl_grid::{AlignedGrid, AllocTracker};
 
 mod dct;
 mod transform;
@@ -28,9 +28,9 @@ pub fn adaptive_lf_smoothing_impl(
     assert_eq!(in_y.len(), in_b.len());
     assert_eq!(in_x.len(), width * height);
 
-    let mut udsum_x = SimpleGrid::with_alloc_tracker(width, height - 2, tracker)?;
-    let mut udsum_y = SimpleGrid::with_alloc_tracker(width, height - 2, tracker)?;
-    let mut udsum_b = SimpleGrid::with_alloc_tracker(width, height - 2, tracker)?;
+    let mut udsum_x = AlignedGrid::with_alloc_tracker(width, height - 2, tracker)?;
+    let mut udsum_y = AlignedGrid::with_alloc_tracker(width, height - 2, tracker)?;
+    let mut udsum_b = AlignedGrid::with_alloc_tracker(width, height - 2, tracker)?;
 
     for (g, out) in [
         (&mut *in_x, udsum_x.buf_mut()),

--- a/crates/jxl-render/src/vardct/transform_common.rs
+++ b/crates/jxl-render/src/vardct/transform_common.rs
@@ -1,4 +1,4 @@
-use jxl_grid::{CutGrid, SharedSubgrid};
+use jxl_grid::{MutableSubgrid, SharedSubgrid};
 use jxl_modular::ChannelShift;
 use jxl_vardct::{BlockInfo, TransformType};
 
@@ -10,11 +10,11 @@ use crate::vardct::{
 #[inline(always)]
 pub unsafe fn transform_varblocks_inner(
     lf: &[SharedSubgrid<f32>; 3],
-    coeff_out: &mut [CutGrid<'_, f32>; 3],
+    coeff_out: &mut [MutableSubgrid<'_, f32>; 3],
     shifts_cbycr: [ChannelShift; 3],
     block_info: &SharedSubgrid<BlockInfo>,
-    dct: unsafe fn(&mut CutGrid<f32>, DctDirection),
-    transform: unsafe fn(&mut CutGrid<f32>, TransformType),
+    dct: unsafe fn(&mut MutableSubgrid<f32>, DctDirection),
+    transform: unsafe fn(&mut MutableSubgrid<f32>, TransformType),
 ) {
     use TransformType::*;
 

--- a/crates/jxl-render/src/vardct/wasm32/dct.rs
+++ b/crates/jxl-render/src/vardct/wasm32/dct.rs
@@ -1,4 +1,4 @@
-use jxl_grid::{CutGrid, SimdVector};
+use jxl_grid::{MutableSubgrid, SimdVector};
 
 use super::super::dct_common::{self, DctDirection};
 use std::arch::wasm32::*;
@@ -27,7 +27,7 @@ pub(crate) fn transpose_lane(lanes: &[Lane]) -> [Lane; 4] {
 }
 
 #[inline(always)]
-pub(crate) unsafe fn dct_2d_wasm32_simd128(io: &mut CutGrid<'_>, direction: DctDirection) {
+pub(crate) unsafe fn dct_2d_wasm32_simd128(io: &mut MutableSubgrid<'_>, direction: DctDirection) {
     if io.width() % LANE_SIZE != 0 || io.height() % LANE_SIZE != 0 {
         return super::generic::dct_2d(io, direction);
     }
@@ -46,7 +46,7 @@ pub(crate) unsafe fn dct_2d_wasm32_simd128(io: &mut CutGrid<'_>, direction: DctD
     dct_2d_lane(&mut io, direction);
 }
 
-fn dct_2d_lane(io: &mut CutGrid<'_, Lane>, direction: DctDirection) {
+fn dct_2d_lane(io: &mut MutableSubgrid<'_, Lane>, direction: DctDirection) {
     let scratch_size = io.height().max(io.width() * LANE_SIZE) * 2;
     unsafe {
         let mut scratch_lanes = vec![Lane::zero(); scratch_size];
@@ -142,7 +142,7 @@ pub(crate) unsafe fn dct8_vec_inverse(vl: Lane, vr: Lane) -> (Lane, Lane) {
     (output0.add(output1), i32x4_shuffle::<3, 2, 1, 0>(sub, sub))
 }
 
-unsafe fn dct8x8(io: &mut CutGrid<'_, Lane>, direction: DctDirection) {
+unsafe fn dct8x8(io: &mut MutableSubgrid<'_, Lane>, direction: DctDirection) {
     let (mut col0, mut col1) = io.split_horizontal(1);
 
     if direction == DctDirection::Forward {
@@ -167,7 +167,7 @@ unsafe fn dct8x8(io: &mut CutGrid<'_, Lane>, direction: DctDirection) {
 }
 
 unsafe fn column_dct_lane(
-    io: &mut CutGrid<'_, Lane>,
+    io: &mut MutableSubgrid<'_, Lane>,
     scratch: &mut [Lane],
     direction: DctDirection,
 ) {
@@ -189,7 +189,11 @@ unsafe fn column_dct_lane(
     }
 }
 
-unsafe fn row_dct_lane(io: &mut CutGrid<'_, Lane>, scratch: &mut [Lane], direction: DctDirection) {
+unsafe fn row_dct_lane(
+    io: &mut MutableSubgrid<'_, Lane>,
+    scratch: &mut [Lane],
+    direction: DctDirection,
+) {
     let width = io.width() * LANE_SIZE;
     let height = io.height();
     let (io_lanes, scratch_lanes) = scratch[..width * 2].split_at_mut(width);
@@ -252,7 +256,7 @@ pub(crate) unsafe fn dct4_inverse(input: [Lane; 4]) -> [Lane; 4] {
 }
 
 #[inline]
-unsafe fn dct8_forward(io: &mut CutGrid<'_, Lane>) {
+unsafe fn dct8_forward(io: &mut MutableSubgrid<'_, Lane>) {
     assert!(io.height() == 8);
     let sec = dct_common::sec_half_small(8);
 
@@ -290,7 +294,7 @@ unsafe fn dct8_forward(io: &mut CutGrid<'_, Lane>) {
 }
 
 #[inline]
-unsafe fn dct8_inverse(io: &mut CutGrid<'_, Lane>) {
+unsafe fn dct8_inverse(io: &mut MutableSubgrid<'_, Lane>) {
     assert!(io.height() == 8);
     let sec = dct_common::sec_half_small(8);
 
@@ -346,9 +350,9 @@ unsafe fn dct(io: &mut [Lane], scratch: &mut [Lane], direction: DctDirection) {
 
     if n == 8 {
         if direction == DctDirection::Forward {
-            dct8_forward(&mut CutGrid::from_buf(io, 1, 8, 1));
+            dct8_forward(&mut MutableSubgrid::from_buf(io, 1, 8, 1));
         } else {
-            dct8_inverse(&mut CutGrid::from_buf(io, 1, 8, 1));
+            dct8_inverse(&mut MutableSubgrid::from_buf(io, 1, 8, 1));
         }
         return;
     }

--- a/crates/jxl-render/src/vardct/wasm32/transform.rs
+++ b/crates/jxl-render/src/vardct/wasm32/transform.rs
@@ -1,6 +1,6 @@
 use std::arch::wasm32::*;
 
-use jxl_grid::{CutGrid, SharedSubgrid, SimdVector};
+use jxl_grid::{MutableSubgrid, SharedSubgrid, SimdVector};
 use jxl_modular::ChannelShift;
 use jxl_vardct::{BlockInfo, TransformType};
 
@@ -8,7 +8,7 @@ use crate::vardct::{dct_common::DctDirection, transform_common::transform_varblo
 
 use super::generic;
 
-unsafe fn transform_dct4_wasm32_simd128(coeff: &mut CutGrid<'_>) {
+unsafe fn transform_dct4_wasm32_simd128(coeff: &mut MutableSubgrid<'_>) {
     generic::aux_idct2_in_place_2(coeff);
 
     let mut scratch_0 = [v128::zero(); 4];
@@ -48,7 +48,7 @@ unsafe fn transform_dct4_wasm32_simd128(coeff: &mut CutGrid<'_>) {
     }
 }
 
-unsafe fn transform_dct4x8_wasm32_simd128<const TR: bool>(coeff: &mut CutGrid<'_>) {
+unsafe fn transform_dct4x8_wasm32_simd128<const TR: bool>(coeff: &mut MutableSubgrid<'_>) {
     let coeff0 = coeff.get(0, 0);
     let coeff1 = coeff.get(0, 1);
     *coeff.get_mut(0, 0) = coeff0 + coeff1;
@@ -135,11 +135,11 @@ unsafe fn transform_dct4x8_wasm32_simd128<const TR: bool>(coeff: &mut CutGrid<'_
     }
 }
 
-unsafe fn transform_dct_wasm32_simd128(coeff: &mut CutGrid<'_>) {
+unsafe fn transform_dct_wasm32_simd128(coeff: &mut MutableSubgrid<'_>) {
     super::dct::dct_2d_wasm32_simd128(coeff, DctDirection::Inverse);
 }
 
-unsafe fn transform_wasm32_simd128(coeff: &mut CutGrid<'_>, dct_select: TransformType) {
+unsafe fn transform_wasm32_simd128(coeff: &mut MutableSubgrid<'_>, dct_select: TransformType) {
     use TransformType::*;
 
     match dct_select {
@@ -158,7 +158,7 @@ unsafe fn transform_wasm32_simd128(coeff: &mut CutGrid<'_>, dct_select: Transfor
 
 unsafe fn transform_varblocks_wasm32_simd128(
     lf: &[SharedSubgrid<f32>; 3],
-    coeff_out: &mut [CutGrid<'_, f32>; 3],
+    coeff_out: &mut [MutableSubgrid<'_, f32>; 3],
     shifts_cbycr: [ChannelShift; 3],
     block_info: &SharedSubgrid<BlockInfo>,
 ) {
@@ -175,7 +175,7 @@ unsafe fn transform_varblocks_wasm32_simd128(
 #[inline]
 pub fn transform_varblocks(
     lf: &[SharedSubgrid<f32>; 3],
-    coeff_out: &mut [CutGrid<'_, f32>; 3],
+    coeff_out: &mut [MutableSubgrid<'_, f32>; 3],
     shifts_cbycr: [ChannelShift; 3],
     block_info: &SharedSubgrid<BlockInfo>,
 ) {

--- a/crates/jxl-render/src/vardct/x86_64/transform.rs
+++ b/crates/jxl-render/src/vardct/x86_64/transform.rs
@@ -1,7 +1,7 @@
 use std::arch::is_x86_feature_detected;
 use std::arch::x86_64::*;
 
-use jxl_grid::{CutGrid, SharedSubgrid};
+use jxl_grid::{MutableSubgrid, SharedSubgrid};
 use jxl_modular::ChannelShift;
 use jxl_vardct::{BlockInfo, TransformType};
 
@@ -11,13 +11,13 @@ use super::generic;
 
 #[target_feature(enable = "sse4.1")]
 #[target_feature(enable = "sse3")]
-unsafe fn transform_dct2_x86_64_sse41(coeff: &mut CutGrid<'_>) {
+unsafe fn transform_dct2_x86_64_sse41(coeff: &mut MutableSubgrid<'_>) {
     generic::aux_idct2_in_place_2(coeff);
     generic::aux_idct2_in_place::<4>(coeff);
     generic::aux_idct2_in_place::<8>(coeff);
 }
 
-fn transform_dct4_x86_64_sse2(coeff: &mut CutGrid<'_>) {
+fn transform_dct4_x86_64_sse2(coeff: &mut MutableSubgrid<'_>) {
     generic::aux_idct2_in_place_2(coeff);
 
     unsafe {
@@ -59,7 +59,7 @@ fn transform_dct4_x86_64_sse2(coeff: &mut CutGrid<'_>) {
     }
 }
 
-fn transform_dct4x8_x86_64_sse2<const TR: bool>(coeff: &mut CutGrid<'_>) {
+fn transform_dct4x8_x86_64_sse2<const TR: bool>(coeff: &mut MutableSubgrid<'_>) {
     let coeff0 = coeff.get(0, 0);
     let coeff1 = coeff.get(0, 1);
     *coeff.get_mut(0, 0) = coeff0 + coeff1;
@@ -148,13 +148,13 @@ fn transform_dct4x8_x86_64_sse2<const TR: bool>(coeff: &mut CutGrid<'_>) {
     }
 }
 
-fn transform_dct(coeff: &mut CutGrid<'_>) {
+fn transform_dct(coeff: &mut MutableSubgrid<'_>) {
     super::dct::dct_2d_x86_64_sse2(coeff, DctDirection::Inverse);
 }
 
 #[target_feature(enable = "sse4.1")]
 #[target_feature(enable = "sse3")]
-unsafe fn transform_x86_64_sse41(coeff: &mut CutGrid<'_>, dct_select: TransformType) {
+unsafe fn transform_x86_64_sse41(coeff: &mut MutableSubgrid<'_>, dct_select: TransformType) {
     use TransformType::*;
 
     match dct_select {
@@ -171,7 +171,7 @@ unsafe fn transform_x86_64_sse41(coeff: &mut CutGrid<'_>, dct_select: TransformT
     }
 }
 
-fn transform_x86_64_sse2(coeff: &mut CutGrid<'_>, dct_select: TransformType) {
+fn transform_x86_64_sse2(coeff: &mut MutableSubgrid<'_>, dct_select: TransformType) {
     use TransformType::*;
 
     match dct_select {
@@ -192,7 +192,7 @@ fn transform_x86_64_sse2(coeff: &mut CutGrid<'_>, dct_select: TransformType) {
 #[target_feature(enable = "sse3")]
 unsafe fn transform_varblocks_x86_64_sse41(
     lf: &[SharedSubgrid<f32>; 3],
-    coeff_out: &mut [CutGrid<'_, f32>; 3],
+    coeff_out: &mut [MutableSubgrid<'_, f32>; 3],
     shifts_cbycr: [ChannelShift; 3],
     block_info: &SharedSubgrid<BlockInfo>,
 ) {
@@ -208,7 +208,7 @@ unsafe fn transform_varblocks_x86_64_sse41(
 
 pub fn transform_varblocks(
     lf: &[SharedSubgrid<f32>; 3],
-    coeff_out: &mut [CutGrid<'_, f32>; 3],
+    coeff_out: &mut [MutableSubgrid<'_, f32>; 3],
     shifts_cbycr: [ChannelShift; 3],
     block_info: &SharedSubgrid<BlockInfo>,
 ) {

--- a/crates/jxl-vardct/src/hf_metadata.rs
+++ b/crates/jxl-vardct/src/hf_metadata.rs
@@ -1,5 +1,5 @@
 use jxl_bitstream::{Bitstream, Bundle};
-use jxl_grid::{AllocTracker, SimpleGrid};
+use jxl_grid::{AlignedGrid, AllocTracker};
 use jxl_modular::{MaConfig, Modular, ModularChannelParams, ModularParams};
 
 use crate::{Result, TransformType};
@@ -24,13 +24,13 @@ pub struct HfMetadataParams<'ma, 'pool, 'tracker> {
 #[derive(Debug)]
 pub struct HfMetadata {
     /// Chroma-from-luma correlation grid for X channel.
-    pub x_from_y: SimpleGrid<i32>,
+    pub x_from_y: AlignedGrid<i32>,
     /// Chroma-from-luma correlation grid for B channel.
-    pub b_from_y: SimpleGrid<i32>,
+    pub b_from_y: AlignedGrid<i32>,
     /// Varblock information in an LF group.
-    pub block_info: SimpleGrid<BlockInfo>,
+    pub block_info: AlignedGrid<BlockInfo>,
     /// Sigma parameter grid for edge-preserving filter.
-    pub epf_sigma: SimpleGrid<f32>,
+    pub epf_sigma: AlignedGrid<f32>,
 }
 
 /// Varblock grid information.
@@ -104,7 +104,7 @@ impl Bundle<HfMetadataParams<'_, '_, '_>> for HfMetadata {
 
         let sharpness = sharpness.buf();
 
-        let mut epf_sigma = SimpleGrid::with_alloc_tracker(bw, bh, tracker)?;
+        let mut epf_sigma = AlignedGrid::with_alloc_tracker(bw, bh, tracker)?;
         let epf_sigma_buf = epf_sigma.buf_mut();
         let epf = epf.map(|(quant_mul, sharp_lut)| {
             (
@@ -113,7 +113,7 @@ impl Bundle<HfMetadataParams<'_, '_, '_>> for HfMetadata {
             )
         });
 
-        let mut block_info = SimpleGrid::<BlockInfo>::with_alloc_tracker(bw, bh, tracker)?;
+        let mut block_info = AlignedGrid::<BlockInfo>::with_alloc_tracker(bw, bh, tracker)?;
         let mut x;
         let mut y = 0usize;
         let mut data_idx = 0usize;


### PR DESCRIPTION
- Renamed: `SimpleGrid` &rarr; `AlignedGrid`
- Renamed: `CutGrid` &rarr; `MutableSubgrid`