### PR TITLE
jxl-render: Separate extra channel upsampling stage when patches are used

### DIFF
--- a/crates/jxl-render/src/features/noise.rs
+++ b/crates/jxl-render/src/features/noise.rs
@@ -13,12 +13,14 @@ pub fn render_noise(
     grid: &mut ImageWithRegion,
     params: &NoiseParameters,
 ) -> Result<()> {
-    let region = grid.regions_and_shifts()[0].0;
+    let (region, shift) = grid.regions_and_shifts()[0];
     let tracker = grid.alloc_tracker().cloned();
     let [grid_r, grid_g, grid_b] = grid.as_color_floats_mut();
 
     let full_frame_region = Region::with_size(header.width, header.height);
-    let actual_region = region.intersection(full_frame_region);
+    let actual_region = region
+        .intersection(full_frame_region)
+        .downsample_with_shift(shift);
 
     let left = actual_region.left as usize;
     let top = actual_region.top as usize;

--- a/crates/jxl-render/src/modular.rs
+++ b/crates/jxl-render/src/modular.rs
@@ -135,7 +135,7 @@ pub(crate) fn render_modular<S: Sample>(
         modular_image.prepare_subimage().unwrap().finish(pool);
     });
 
-    let mut fb = ImageWithRegion::new(tracker);
+    let mut fb = ImageWithRegion::new(frame_header.encoded_color_channels(), tracker);
     fb.extend_from_gmodular(gmodular);
 
     if xyb_encoded {

--- a/crates/jxl-render/src/render.rs
+++ b/crates/jxl-render/src/render.rs
@@ -206,9 +206,12 @@ fn render_features<S: Sample>(
     }
 
     if let Some(splines) = &lf_global.splines {
+        grid.convert_modular_color(image_header.metadata.bit_depth)?;
         features::render_spline(frame_header, grid, splines, base_correlations_xb)?;
     }
+
     if let Some(noise) = &lf_global.noise {
+        grid.convert_modular_color(image_header.metadata.bit_depth)?;
         features::render_noise(
             frame.header(),
             visible_frames_num,

--- a/crates/jxl-render/src/vardct/mod.rs
+++ b/crates/jxl-render/src/vardct/mod.rs
@@ -202,7 +202,7 @@ pub(crate) fn render_vardct<S: Sample>(
             });
             let Region { width, height, .. } = modular_region;
 
-            let mut fb = ImageWithRegion::new(tracker);
+            let mut fb = ImageWithRegion::new(3, tracker);
             for shift in shifts_cbycr {
                 let (width, height) = shift.shift_size((width, height));
                 let buffer =

--- a/crates/jxl-vardct/src/dequant.rs
+++ b/crates/jxl-vardct/src/dequant.rs
@@ -391,7 +391,6 @@ impl DequantMatrixParams {
         }
 
         for w in weights.iter().flatten() {
-            tracing::trace!(w);
             if *w >= 1e8 || *w <= 0.0 {
                 tracing::error!(w, "Dequant matrix has too large or non-positive element");
                 return Err(jxl_bitstream::Error::ValidationFailed(


### PR DESCRIPTION
- Refactor non-separable upsampling.
- Move upsampling stage after rendering features.
  - Upsample extra channels to match color channels first, when patches are used.
- Remove unused trace log in jxl-vardct.