### PR TITLE
jxl-oxide-cli: Add devtool subcommand `progressive`

### DIFF
--- a/crates/jxl-oxide-cli/src/commands.rs
+++ b/crates/jxl-oxide-cli/src/commands.rs
@@ -3,6 +3,8 @@ pub mod decode;
 #[cfg(feature = "__devtools")]
 pub mod generate_fixture;
 pub mod info;
+#[cfg(feature = "__devtools")]
+pub mod progressive;
 #[cfg(test)]
 pub mod tests;
 
@@ -11,6 +13,8 @@ pub use decode::DecodeArgs;
 #[cfg(feature = "__devtools")]
 pub use generate_fixture::GenerateFixtureArgs;
 pub use info::InfoArgs;
+#[cfg(feature = "__devtools")]
+pub use progressive::ProgressiveArgs;
 
 #[derive(Debug, clap::Parser)]
 #[command(version)]
@@ -43,6 +47,9 @@ pub enum Subcommands {
     /// Print information about JPEG XL image.
     #[command(short_flag = 'I')]
     Info(InfoArgs),
+    /// (devtools) Generate frames for progressive decoding animation.
+    #[cfg(feature = "__devtools")]
+    Progressive(ProgressiveArgs),
     /// (devtools) Generate fixture to use for testing.
     #[cfg(feature = "__devtools")]
     GenerateFixture(GenerateFixtureArgs),

--- a/crates/jxl-oxide-cli/src/commands/progressive.rs
+++ b/crates/jxl-oxide-cli/src/commands/progressive.rs
@@ -1,0 +1,20 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+#[non_exhaustive]
+pub struct ProgressiveArgs {
+    /// Input file
+    pub input: PathBuf,
+    /// Bytes to feed per frame, in bytes
+    #[arg(short, long)]
+    pub step: u64,
+    /// Output directory path
+    #[arg(short, long)]
+    pub output: Option<PathBuf>,
+    /// Number of parallelism to use
+    #[cfg(feature = "rayon")]
+    #[arg(short = 'j', long)]
+    pub num_threads: Option<usize>,
+}

--- a/crates/jxl-oxide-cli/src/decode.rs
+++ b/crates/jxl-oxide-cli/src/decode.rs
@@ -1,13 +1,9 @@
-use std::io::prelude::*;
 use std::time::Duration;
 
-use jxl_oxide::{
-    AllocTracker, CropInfo, EnumColourEncoding, FrameBuffer, JxlImage, JxlThreadPool, PixelFormat,
-    Render,
-};
+use jxl_oxide::{AllocTracker, CropInfo, EnumColourEncoding, JxlImage, JxlThreadPool, Render};
 
 use crate::commands::decode::*;
-use crate::{Error, Result};
+use crate::{output, Error, Result};
 
 pub fn handle_decode(args: DecodeArgs) -> Result<()> {
     let _guard = tracing::trace_span!("Handle decode subcommand").entered();
@@ -170,7 +166,7 @@ pub fn handle_decode(args: DecodeArgs) -> Result<()> {
                     None
                 };
 
-                write_png(
+                output::write_png(
                     output,
                     &image,
                     &keyframes,
@@ -182,7 +178,7 @@ pub fn handle_decode(args: DecodeArgs) -> Result<()> {
                 .map_err(Error::WriteImage)?;
             }
             OutputFormat::Png8 => {
-                write_png(
+                output::write_png(
                     output,
                     &image,
                     &keyframes,
@@ -194,7 +190,7 @@ pub fn handle_decode(args: DecodeArgs) -> Result<()> {
                 .map_err(Error::WriteImage)?;
             }
             OutputFormat::Png16 => {
-                write_png(
+                output::write_png(
                     output,
                     &image,
                     &keyframes,
@@ -210,7 +206,7 @@ pub fn handle_decode(args: DecodeArgs) -> Result<()> {
                     tracing::warn!("--icc-output is not set. Numpy buffer alone cannot be used to display image as its colorspace is unknown.");
                 }
 
-                write_npy(output, &keyframes, width, height).map_err(Error::WriteImage)?;
+                output::write_npy(output, &keyframes, width, height).map_err(Error::WriteImage)?;
             }
         }
     } else {
@@ -257,151 +253,4 @@ fn run_once(image: &mut JxlImage) -> Result<(Vec<Render>, Duration)> {
 
     let elapsed = decode_start.elapsed();
     Ok((keyframes, elapsed))
-}
-
-fn write_png<W: Write>(
-    output: W,
-    image: &JxlImage,
-    keyframes: &[Render],
-    pixfmt: PixelFormat,
-    force_bit_depth: Option<png::BitDepth>,
-    width: u32,
-    height: u32,
-) -> std::io::Result<()> {
-    // Color encoding information
-    let source_icc = image.rendered_icc();
-    let cicp = image.rendered_cicp();
-    let metadata = &image.image_header().metadata;
-
-    let mut encoder = png::Encoder::new(output, width, height);
-
-    let color_type = match pixfmt {
-        PixelFormat::Gray => png::ColorType::Grayscale,
-        PixelFormat::Graya => png::ColorType::GrayscaleAlpha,
-        PixelFormat::Rgb => png::ColorType::Rgb,
-        PixelFormat::Rgba => png::ColorType::Rgba,
-        _ => {
-            tracing::error!("Cannot output CMYK PNG");
-            panic!();
-        }
-    };
-    encoder.set_color(color_type);
-
-    let bit_depth = force_bit_depth.unwrap_or(if metadata.bit_depth.bits_per_sample() > 8 {
-        png::BitDepth::Sixteen
-    } else {
-        png::BitDepth::Eight
-    });
-    let sixteen_bits = bit_depth == png::BitDepth::Sixteen;
-    if sixteen_bits {
-        encoder.set_depth(png::BitDepth::Sixteen);
-    } else {
-        encoder.set_depth(png::BitDepth::Eight);
-    }
-
-    if let Some(animation) = &metadata.animation {
-        let num_plays = animation.num_loops;
-        encoder
-            .set_animated(keyframes.len() as u32, num_plays)
-            .unwrap();
-    }
-
-    encoder.validate_sequence(true);
-
-    let mut writer = encoder.write_header()?;
-
-    tracing::debug!("Embedding ICC profile");
-    let compressed_icc = miniz_oxide::deflate::compress_to_vec_zlib(&source_icc, 7);
-    let mut iccp_chunk_data = vec![b'0', 0, 0];
-    iccp_chunk_data.extend(compressed_icc);
-    writer.write_chunk(png::chunk::iCCP, &iccp_chunk_data)?;
-
-    if let Some(cicp) = cicp {
-        tracing::debug!(cicp = format_args!("{:?}", cicp), "Writing cICP chunk");
-        writer.write_chunk(png::chunk::ChunkType([b'c', b'I', b'C', b'P']), &cicp)?;
-    }
-
-    tracing::debug!("Writing image data");
-    for keyframe in keyframes {
-        if let Some(animation) = &metadata.animation {
-            let duration = keyframe.duration();
-            let numer = animation.tps_denominator * duration;
-            let denom = animation.tps_numerator;
-            let (numer, denom) = if numer >= 0x10000 || denom >= 0x10000 {
-                if duration == 0xffffffff {
-                    tracing::warn!(numer, denom, "Writing multi-page image in APNG");
-                } else {
-                    tracing::warn!(numer, denom, "Frame duration is not representable in APNG");
-                }
-                let duration = (numer as f32 / denom as f32) * 65535.0;
-                (duration as u16, 0xffffu16)
-            } else {
-                (numer as u16, denom as u16)
-            };
-            writer.set_frame_delay(numer, denom).unwrap();
-        }
-
-        let mut stream = keyframe.stream();
-        let mut fb = FrameBuffer::new(
-            stream.width() as usize,
-            stream.height() as usize,
-            stream.channels() as usize,
-        );
-        stream.write_to_buffer(fb.buf_mut());
-
-        if sixteen_bits {
-            let mut buf = vec![0u8; fb.width() * fb.height() * fb.channels() * 2];
-            for (b, s) in buf.chunks_exact_mut(2).zip(fb.buf()) {
-                let w = (*s * 65535.0 + 0.5).clamp(0.0, 65535.0) as u16;
-                let [b0, b1] = w.to_be_bytes();
-                b[0] = b0;
-                b[1] = b1;
-            }
-            writer.write_image_data(&buf)?;
-        } else {
-            let mut buf = vec![0u8; fb.width() * fb.height() * fb.channels()];
-            for (b, s) in buf.iter_mut().zip(fb.buf()) {
-                *b = (*s * 255.0 + 0.5).clamp(0.0, 255.0) as u8;
-            }
-            writer.write_image_data(&buf)?;
-        }
-    }
-
-    writer.finish()?;
-    Ok(())
-}
-
-fn write_npy<W: Write>(
-    output: W,
-    keyframes: &[Render],
-    width: u32,
-    height: u32,
-) -> std::io::Result<()> {
-    let channels = {
-        let first_frame = keyframes.first().unwrap();
-        first_frame.color_channels().len() + first_frame.extra_channels().0.len()
-    };
-
-    let mut output = std::io::BufWriter::new(output);
-    output.write_all(b"\x93NUMPY\x01\x00").unwrap();
-    let header = format!(
-        "{{'descr': '<f4', 'fortran_order': False, 'shape': ({}, {}, {}, {}), }}\n",
-        keyframes.len(),
-        height,
-        width,
-        channels,
-    );
-    output.write_all(&(header.len() as u16).to_le_bytes())?;
-    output.write_all(header.as_bytes())?;
-
-    tracing::debug!("Writing image data");
-    for keyframe in keyframes {
-        let fb = keyframe.image_all_channels();
-        for sample in fb.buf() {
-            output.write_all(&sample.to_bits().to_le_bytes())?;
-        }
-    }
-
-    output.flush()?;
-    Ok(())
 }

--- a/crates/jxl-oxide-cli/src/lib.rs
+++ b/crates/jxl-oxide-cli/src/lib.rs
@@ -4,6 +4,10 @@ pub mod error;
 #[cfg(feature = "__devtools")]
 pub mod generate_fixture;
 pub mod info;
+#[cfg(feature = "__devtools")]
+pub mod progressive;
+
+mod output;
 
 pub use commands::{Args, Subcommands};
 pub use error::Error;

--- a/crates/jxl-oxide-cli/src/main.rs
+++ b/crates/jxl-oxide-cli/src/main.rs
@@ -36,6 +36,10 @@ fn main() -> std::process::ExitCode {
             jxl_oxide_cli::generate_fixture::handle_generate_fixture(args);
             Ok(())
         }
+        #[cfg(feature = "__devtools")]
+        Some(Subcommands::Progressive(args)) => {
+            jxl_oxide_cli::progressive::handle_progressive(args)
+        }
     };
 
     if let Err(e) = result {

--- a/crates/jxl-oxide-cli/src/output.rs
+++ b/crates/jxl-oxide-cli/src/output.rs
@@ -1,0 +1,150 @@
+use std::io::prelude::*;
+
+use jxl_oxide::{FrameBuffer, JxlImage, PixelFormat, Render};
+
+pub(crate) fn write_png<W: Write>(
+    output: W,
+    image: &JxlImage,
+    keyframes: &[Render],
+    pixfmt: PixelFormat,
+    force_bit_depth: Option<png::BitDepth>,
+    width: u32,
+    height: u32,
+) -> std::io::Result<()> {
+    // Color encoding information
+    let source_icc = image.rendered_icc();
+    let cicp = image.rendered_cicp();
+    let metadata = &image.image_header().metadata;
+
+    let mut encoder = png::Encoder::new(output, width, height);
+
+    let color_type = match pixfmt {
+        PixelFormat::Gray => png::ColorType::Grayscale,
+        PixelFormat::Graya => png::ColorType::GrayscaleAlpha,
+        PixelFormat::Rgb => png::ColorType::Rgb,
+        PixelFormat::Rgba => png::ColorType::Rgba,
+        _ => {
+            tracing::error!("Cannot output CMYK PNG");
+            panic!();
+        }
+    };
+    encoder.set_color(color_type);
+
+    let bit_depth = force_bit_depth.unwrap_or(if metadata.bit_depth.bits_per_sample() > 8 {
+        png::BitDepth::Sixteen
+    } else {
+        png::BitDepth::Eight
+    });
+    let sixteen_bits = bit_depth == png::BitDepth::Sixteen;
+    if sixteen_bits {
+        encoder.set_depth(png::BitDepth::Sixteen);
+    } else {
+        encoder.set_depth(png::BitDepth::Eight);
+    }
+
+    if let Some(animation) = &metadata.animation {
+        let num_plays = animation.num_loops;
+        encoder
+            .set_animated(keyframes.len() as u32, num_plays)
+            .unwrap();
+    }
+
+    encoder.validate_sequence(true);
+
+    let mut writer = encoder.write_header()?;
+
+    tracing::debug!("Embedding ICC profile");
+    let compressed_icc = miniz_oxide::deflate::compress_to_vec_zlib(&source_icc, 7);
+    let mut iccp_chunk_data = vec![b'0', 0, 0];
+    iccp_chunk_data.extend(compressed_icc);
+    writer.write_chunk(png::chunk::iCCP, &iccp_chunk_data)?;
+
+    if let Some(cicp) = cicp {
+        tracing::debug!(cicp = format_args!("{:?}", cicp), "Writing cICP chunk");
+        writer.write_chunk(png::chunk::ChunkType([b'c', b'I', b'C', b'P']), &cicp)?;
+    }
+
+    tracing::debug!("Writing image data");
+    for keyframe in keyframes {
+        if let Some(animation) = &metadata.animation {
+            let duration = keyframe.duration();
+            let numer = animation.tps_denominator * duration;
+            let denom = animation.tps_numerator;
+            let (numer, denom) = if numer >= 0x10000 || denom >= 0x10000 {
+                if duration == 0xffffffff {
+                    tracing::warn!(numer, denom, "Writing multi-page image in APNG");
+                } else {
+                    tracing::warn!(numer, denom, "Frame duration is not representable in APNG");
+                }
+                let duration = (numer as f32 / denom as f32) * 65535.0;
+                (duration as u16, 0xffffu16)
+            } else {
+                (numer as u16, denom as u16)
+            };
+            writer.set_frame_delay(numer, denom).unwrap();
+        }
+
+        let mut stream = keyframe.stream();
+        let mut fb = FrameBuffer::new(
+            stream.width() as usize,
+            stream.height() as usize,
+            stream.channels() as usize,
+        );
+        stream.write_to_buffer(fb.buf_mut());
+
+        if sixteen_bits {
+            let mut buf = vec![0u8; fb.width() * fb.height() * fb.channels() * 2];
+            for (b, s) in buf.chunks_exact_mut(2).zip(fb.buf()) {
+                let w = (*s * 65535.0 + 0.5).clamp(0.0, 65535.0) as u16;
+                let [b0, b1] = w.to_be_bytes();
+                b[0] = b0;
+                b[1] = b1;
+            }
+            writer.write_image_data(&buf)?;
+        } else {
+            let mut buf = vec![0u8; fb.width() * fb.height() * fb.channels()];
+            for (b, s) in buf.iter_mut().zip(fb.buf()) {
+                *b = (*s * 255.0 + 0.5).clamp(0.0, 255.0) as u8;
+            }
+            writer.write_image_data(&buf)?;
+        }
+    }
+
+    writer.finish()?;
+    Ok(())
+}
+
+pub(crate) fn write_npy<W: Write>(
+    output: W,
+    keyframes: &[Render],
+    width: u32,
+    height: u32,
+) -> std::io::Result<()> {
+    let channels = {
+        let first_frame = keyframes.first().unwrap();
+        first_frame.color_channels().len() + first_frame.extra_channels().0.len()
+    };
+
+    let mut output = std::io::BufWriter::new(output);
+    output.write_all(b"\x93NUMPY\x01\x00").unwrap();
+    let header = format!(
+        "{{'descr': '<f4', 'fortran_order': False, 'shape': ({}, {}, {}, {}), }}\n",
+        keyframes.len(),
+        height,
+        width,
+        channels,
+    );
+    output.write_all(&(header.len() as u16).to_le_bytes())?;
+    output.write_all(header.as_bytes())?;
+
+    tracing::debug!("Writing image data");
+    for keyframe in keyframes {
+        let fb = keyframe.image_all_channels();
+        for sample in fb.buf() {
+            output.write_all(&sample.to_bits().to_le_bytes())?;
+        }
+    }
+
+    output.flush()?;
+    Ok(())
+}

--- a/crates/jxl-oxide-cli/src/progressive.rs
+++ b/crates/jxl-oxide-cli/src/progressive.rs
@@ -1,0 +1,155 @@
+use std::io::prelude::*;
+use std::path::Path;
+
+use jxl_oxide::{JxlImage, JxlThreadPool, Render};
+
+use crate::commands::progressive::*;
+use crate::{output, Error, Result};
+
+pub fn handle_progressive(args: ProgressiveArgs) -> Result<()> {
+    let _guard = tracing::trace_span!("Handle progressive subcommand").entered();
+
+    #[cfg(feature = "rayon")]
+    let pool = JxlThreadPool::rayon(args.num_threads);
+    #[cfg(not(feature = "rayon"))]
+    let pool = JxlThreadPool::none();
+
+    let mut uninit_image = JxlImage::builder().pool(pool.clone()).build_uninit();
+
+    let mut input = std::fs::File::open(&args.input).map_err(|e| Error::ReadJxl(e.into()))?;
+    let mut buf = vec![0u8; args.step as usize];
+    let mut idx = 0usize;
+
+    let output_dir = args.output.as_deref();
+    if let Some(output_dir) = output_dir {
+        std::fs::create_dir_all(output_dir).map_err(Error::WriteImage)?;
+    } else {
+        tracing::info!("No output path specified, skipping output encoding");
+    }
+
+    let mut image = loop {
+        let current_iter = idx;
+
+        let buf = fill_buf(&mut input, &mut buf)?;
+        if buf.is_empty() {
+            tracing::warn!("Partial image");
+            return Ok(());
+        }
+
+        uninit_image.feed_bytes(buf).map_err(Error::ReadJxl)?;
+        idx += 1;
+        let init_result = uninit_image.try_init().map_err(Error::ReadJxl)?;
+        match init_result {
+            jxl_oxide::InitializeResult::NeedMoreData(image) => uninit_image = image,
+            jxl_oxide::InitializeResult::Initialized(mut image) => {
+                run_once(&mut image, current_iter, output_dir)?;
+                break image;
+            }
+        }
+
+        tracing::info!("Iteration {current_iter} didn't produce an image");
+    };
+
+    loop {
+        let current_iter = idx;
+
+        let buf = fill_buf(&mut input, &mut buf)?;
+        if buf.is_empty() {
+            break;
+        }
+
+        image.feed_bytes(buf).map_err(Error::ReadJxl)?;
+        idx += 1;
+        run_once(&mut image, current_iter, output_dir)?;
+    }
+
+    if !image.is_loading_done() {
+        tracing::warn!("Partial image");
+    }
+
+    if output_dir.is_none() {
+        tracing::info!("No output path specified, skipping output encoding");
+    }
+
+    Ok(())
+}
+
+fn run_once(image: &mut JxlImage, current_iter: usize, output_dir: Option<&Path>) -> Result<()> {
+    match (image.num_loaded_keyframes(), image.is_loading_done()) {
+        (0, false) | (1, true) => {}
+        _ => {
+            tracing::error!("Progressive decoding doesn't support animation");
+            return Err(Error::ReadJxl(
+                "Progressive decoding doesn't support animation".into(),
+            ));
+        }
+    }
+
+    fn run_inner(image: &mut JxlImage) -> Result<Option<Render>> {
+        Ok(if image.is_loading_done() {
+            Some(image.render_frame_cropped(0).map_err(Error::Render)?)
+        } else {
+            image.render_loading_frame_cropped().ok()
+        })
+    }
+
+    let mut output = None;
+
+    let decode_start = std::time::Instant::now();
+    #[cfg(feature = "rayon")]
+    if let Some(rayon_pool) = image.pool().clone().as_rayon_pool() {
+        output = rayon_pool.install(|| run_inner(image))?;
+    }
+
+    if output.is_none() {
+        output = run_inner(image)?;
+    }
+
+    let elapsed = decode_start.elapsed();
+    let elapsed_seconds = elapsed.as_secs_f64();
+    let elapsed_msecs = elapsed_seconds * 1000.0;
+
+    let Some(render) = output else {
+        tracing::info!(
+            "Iteration {current_iter} took {elapsed_msecs:.2} ms; didn't produce an image"
+        );
+        return Ok(());
+    };
+    tracing::info!("Iteration {current_iter} took {elapsed_msecs:.2} ms");
+
+    let Some(output_dir) = output_dir else {
+        return Ok(());
+    };
+
+    let mut output_path = output_dir.to_owned();
+    output_path.push(format!("frame{current_iter}.png"));
+    let output = std::fs::File::create(output_path).map_err(Error::WriteImage)?;
+
+    let width = image.width();
+    let height = image.height();
+    output::write_png(
+        output,
+        image,
+        &[render],
+        image.pixel_format(),
+        None,
+        width,
+        height,
+    )
+    .map_err(Error::WriteImage)
+}
+
+fn fill_buf<R: Read>(mut reader: R, buf: &mut [u8]) -> Result<&mut [u8]> {
+    let mut bytes_read = 0;
+    loop {
+        let cnt = reader
+            .read(&mut buf[bytes_read..])
+            .map_err(|e| Error::ReadJxl(e.into()))?;
+        if cnt == 0 {
+            break;
+        }
+        bytes_read += cnt;
+    }
+
+    Ok(&mut buf[..bytes_read])
+}

--- a/crates/jxl-oxide-cli/src/progressive.rs
+++ b/crates/jxl-oxide-cli/src/progressive.rs
@@ -17,6 +17,13 @@ pub fn handle_progressive(args: ProgressiveArgs) -> Result<()> {
     let mut uninit_image = JxlImage::builder().pool(pool.clone()).build_uninit();
 
     let mut input = std::fs::File::open(&args.input).map_err(|e| Error::ReadJxl(e.into()))?;
+    if let Ok(meta) = input.metadata() {
+        let total_iters = meta.len().div_ceil(args.step);
+        tracing::info!(
+            "Will do {total_iters} iteration{}",
+            if total_iters == 1 { "" } else { "s" },
+        );
+    }
     let mut buf = vec![0u8; args.step as usize];
     let mut idx = 0usize;
 


### PR DESCRIPTION
Add a new devtool subcommand `progressive`, which can be used to test partial decoding and progressive rendering.

Usage example:

```
jxl-oxide progressive input.jxl --step 1024 -o path/to/output/dir/
```