### PR TITLE
Document `image` crate integration on docs.rs

### DIFF
--- a/crates/jxl-oxide/Cargo.toml
+++ b/crates/jxl-oxide/Cargo.toml
@@ -66,6 +66,9 @@ lcms2 = ["dep:lcms2"]
 rayon = ["jxl-threadpool/rayon"]
 __examples = ["image?/png"]
 
+[package.metadata.docs.rs]
+features = ["image"]
+
 [[example]]
 name = "image-integration"
 required-features = ["image", "__examples"]

--- a/crates/jxl-oxide/src/lib.rs
+++ b/crates/jxl-oxide/src/lib.rs
@@ -143,6 +143,9 @@
 //! - `rayon`: Enable multithreading with Rayon. (*default*)
 //! - `image`: Enable integration with `image` crate.
 //! - `lcms2`: Enable integration with Little CMS 2.
+
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 use std::sync::Arc;
 
 use jxl_bitstream::{Bitstream, ContainerDetectingReader, ParseEvent};


### PR DESCRIPTION
Right now the `image` feature in `jxl-oxide` crate is disabled on docs.rs. Because of that the docs on the integration do not show up on docs.rs at all. This PR fixes that.

### Details

`doc_auto_cfg` is a [nightly rustdoc feature](https://doc.rust-lang.org/rustdoc/unstable-features.html), so it's only enabled for docs.rs to make it possible to build the docs for this crate on stable. All ways of documenting conditional features are currently nightly-only, but are also widely used so they're unlikely to outright break.

You can preview the generated documentation with this command: `cargo +nightly rustdoc --open --features=image -- --cfg=docsrs`

It looks like this: 
![Screenshot from 2024-11-05 12 11 49](https://github.com/user-attachments/assets/6dad4570-be9f-458d-ae6d-636bf4366d1f)