### PR TITLE
Extract (potentially Brotli-compressed) Exif metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +160,16 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
 
 [[package]]
 name = "bumpalo"
@@ -833,6 +858,7 @@ dependencies = [
 name = "jxl-oxide"
 version = "0.11.0"
 dependencies = [
+ "brotli-decompressor",
  "bytemuck",
  "image",
  "jxl-bitstream",

--- a/crates/jxl-bitstream/src/container.rs
+++ b/crates/jxl-bitstream/src/container.rs
@@ -20,13 +20,14 @@ enum DetectState {
     WaitingBoxHeader,
     WaitingJxlpIndex(ContainerBoxHeader),
     InAuxBox {
-        #[allow(unused)]
         header: ContainerBoxHeader,
+        brotli_box_type: Option<ContainerBoxType>,
         bytes_left: Option<usize>,
     },
     InCodestream {
         kind: BitstreamKind,
         bytes_left: Option<usize>,
+        pending_no_more_aux_box: bool,
     },
 }
 

--- a/crates/jxl-bitstream/src/container/box_header.rs
+++ b/crates/jxl-bitstream/src/container/box_header.rs
@@ -3,7 +3,7 @@ use crate::Error;
 /// Box header used in JPEG XL containers.
 #[derive(Debug, Clone)]
 pub struct ContainerBoxHeader {
-    ty: ContainerBoxType,
+    pub(super) ty: ContainerBoxType,
     box_size: Option<u64>,
     is_last: bool,
 }

--- a/crates/jxl-bitstream/src/container/parse.rs
+++ b/crates/jxl-bitstream/src/container/parse.rs
@@ -40,6 +40,7 @@ impl<'inner, 'buf> ParseEvents<'inner, 'buf> {
                         *state = DetectState::InCodestream {
                             kind: BitstreamKind::BareCodestream,
                             bytes_left: None,
+                            pending_no_more_aux_box: true,
                         };
                         return Ok(Some(ParseEvent::BitstreamKind(
                             BitstreamKind::BareCodestream,
@@ -56,6 +57,7 @@ impl<'inner, 'buf> ParseEvents<'inner, 'buf> {
                         *state = DetectState::InCodestream {
                             kind: BitstreamKind::Invalid,
                             bytes_left: None,
+                            pending_no_more_aux_box: true,
                         };
                         return Ok(Some(ParseEvent::BitstreamKind(BitstreamKind::Invalid)));
                     } else {
@@ -84,9 +86,11 @@ impl<'inner, 'buf> ParseEvents<'inner, 'buf> {
                                 }
                             }
 
+                            let bytes_left = header.box_size().map(|x| x as usize);
                             *state = DetectState::InCodestream {
                                 kind: BitstreamKind::Container,
-                                bytes_left: header.box_size().map(|x| x as usize),
+                                bytes_left,
+                                pending_no_more_aux_box: bytes_left.is_none(),
                             };
                         } else if tbox == ContainerBoxType::PARTIAL_CODESTREAM {
                             if let Some(box_size) = header.box_size() {
@@ -115,7 +119,32 @@ impl<'inner, 'buf> ParseEvents<'inner, 'buf> {
                             *state = DetectState::WaitingJxlpIndex(header);
                         } else {
                             let bytes_left = header.box_size().map(|x| x as usize);
-                            *state = DetectState::InAuxBox { header, bytes_left };
+                            let ty = header.box_type();
+                            let mut brotli_compressed = ty == ContainerBoxType::BROTLI_COMPRESSED;
+                            if brotli_compressed {
+                                if let Some(0..=3) = bytes_left {
+                                    tracing::error!(
+                                        bytes_left = bytes_left.unwrap(),
+                                        "Brotli-compressed box is too small"
+                                    );
+                                    return Err(Error::InvalidBox);
+                                }
+                                brotli_compressed = true;
+                            }
+
+                            *state = DetectState::InAuxBox {
+                                header,
+                                brotli_box_type: None,
+                                bytes_left,
+                            };
+
+                            if !brotli_compressed {
+                                return Ok(Some(ParseEvent::AuxBoxStart {
+                                    ty,
+                                    brotli_compressed: false,
+                                    last_box: bytes_left.is_none(),
+                                }));
+                            }
                         }
                     }
                     HeaderParseResult::NeedMoreData => return Ok(None),
@@ -149,10 +178,19 @@ impl<'inner, 'buf> ParseEvents<'inner, 'buf> {
                         }
                     }
 
+                    let bytes_left = header.box_size().map(|x| x as usize - 4);
                     *state = DetectState::InCodestream {
                         kind: BitstreamKind::Container,
-                        bytes_left: header.box_size().map(|x| x as usize - 4),
+                        bytes_left,
+                        pending_no_more_aux_box: bytes_left.is_none(),
                     };
+                }
+                DetectState::InCodestream {
+                    pending_no_more_aux_box: pending @ true,
+                    ..
+                } => {
+                    *pending = false;
+                    return Ok(Some(ParseEvent::NoMoreAuxBox));
                 }
                 DetectState::InCodestream {
                     bytes_left: None, ..
@@ -179,29 +217,100 @@ impl<'inner, 'buf> ParseEvents<'inner, 'buf> {
                     return Ok(Some(ParseEvent::Codestream(payload)));
                 }
                 DetectState::InAuxBox {
-                    header: _,
+                    header:
+                        ContainerBoxHeader {
+                            ty: ContainerBoxType::BROTLI_COMPRESSED,
+                            ..
+                        },
+                    brotli_box_type: brotli_box_type @ None,
                     bytes_left: None,
                 } => {
-                    let _payload = *buf;
-                    *buf = &[];
-                    // FIXME: emit auxiliary box event
+                    if buf.len() < 4 {
+                        return Ok(None);
+                    }
+
+                    let (ty_slice, remaining) = buf.split_at(4);
+                    *buf = remaining;
+
+                    let mut ty = [0u8; 4];
+                    ty.copy_from_slice(ty_slice);
+                    let ty = ContainerBoxType(ty);
+                    *brotli_box_type = Some(ty);
+                    return Ok(Some(ParseEvent::AuxBoxStart {
+                        ty,
+                        brotli_compressed: true,
+                        last_box: true,
+                    }));
                 }
                 DetectState::InAuxBox {
-                    header: _,
+                    header:
+                        ContainerBoxHeader {
+                            ty: ContainerBoxType::BROTLI_COMPRESSED,
+                            ..
+                        },
+                    brotli_box_type: brotli_box_type @ None,
                     bytes_left: Some(bytes_left),
                 } => {
-                    let _payload = if buf.len() >= *bytes_left {
-                        let (payload, remaining) = buf.split_at(*bytes_left);
-                        *state = DetectState::WaitingBoxHeader;
-                        *buf = remaining;
-                        payload
+                    if buf.len() < 4 {
+                        return Ok(None);
+                    }
+
+                    let (ty_slice, remaining) = buf.split_at(4);
+                    *buf = remaining;
+                    *bytes_left -= 4;
+
+                    let mut ty = [0u8; 4];
+                    ty.copy_from_slice(ty_slice);
+                    let ty = ContainerBoxType(ty);
+                    *brotli_box_type = Some(ty);
+                    return Ok(Some(ParseEvent::AuxBoxStart {
+                        ty,
+                        brotli_compressed: true,
+                        last_box: false,
+                    }));
+                }
+                DetectState::InAuxBox {
+                    header: ContainerBoxHeader { ty, .. },
+                    brotli_box_type,
+                    bytes_left: None,
+                } => {
+                    let ty = if let Some(ty) = brotli_box_type {
+                        *ty
                     } else {
-                        let payload = *buf;
-                        *bytes_left -= buf.len();
-                        *buf = &[];
-                        payload
+                        *ty
                     };
-                    // FIXME: emit auxiliary box event
+                    let payload = *buf;
+                    *buf = &[];
+                    return Ok(Some(ParseEvent::AuxBoxData(ty, payload)));
+                }
+                DetectState::InAuxBox {
+                    header: ContainerBoxHeader { ty, .. },
+                    brotli_box_type,
+                    bytes_left: Some(0),
+                } => {
+                    let ty = if let Some(ty) = brotli_box_type {
+                        *ty
+                    } else {
+                        *ty
+                    };
+                    *state = DetectState::WaitingBoxHeader;
+                    return Ok(Some(ParseEvent::AuxBoxEnd(ty)));
+                }
+                DetectState::InAuxBox {
+                    header: ContainerBoxHeader { ty, .. },
+                    brotli_box_type,
+                    bytes_left: Some(bytes_left),
+                } => {
+                    let ty = if let Some(ty) = brotli_box_type {
+                        *ty
+                    } else {
+                        *ty
+                    };
+                    let num_bytes_to_read = (*bytes_left).min(buf.len());
+                    let (payload, remaining) = buf.split_at(num_bytes_to_read);
+                    *bytes_left -= num_bytes_to_read;
+                    *buf = remaining;
+                    return Ok(Some(ParseEvent::AuxBoxData(ty, payload)));
                 }
             }
         }
@@ -250,6 +359,14 @@ pub enum ParseEvent<'buf> {
     /// Returned data may be partial. Complete codestream can be obtained by concatenating all data
     /// of `Codestream` events.
     Codestream(&'buf [u8]),
+    NoMoreAuxBox,
+    AuxBoxStart {
+        ty: ContainerBoxType,
+        brotli_compressed: bool,
+        last_box: bool,
+    },
+    AuxBoxData(ContainerBoxType, &'buf [u8]),
+    AuxBoxEnd(ContainerBoxType),
 }
 
 impl std::fmt::Debug for ParseEvent<'_> {
@@ -260,6 +377,23 @@ impl std::fmt::Debug for ParseEvent<'_> {
                 .debug_tuple("Codestream")
                 .field(&format_args!("{} byte(s)", buf.len()))
                 .finish(),
+            Self::NoMoreAuxBox => write!(f, "NoMoreAuxBox"),
+            Self::AuxBoxStart {
+                ty,
+                brotli_compressed,
+                last_box,
+            } => f
+                .debug_struct("AuxBoxStart")
+                .field("ty", ty)
+                .field("brotli_compressed", brotli_compressed)
+                .field("last_box", last_box)
+                .finish(),
+            Self::AuxBoxData(ty, buf) => f
+                .debug_tuple("AuxBoxData")
+                .field(ty)
+                .field(&format_args!("{} byte(s)", buf.len()))
+                .finish(),
+            Self::AuxBoxEnd(ty) => f.debug_tuple("AuxBoxEnd").field(&ty).finish(),
         }
     }
 }

--- a/crates/jxl-oxide-cli/src/info.rs
+++ b/crates/jxl-oxide-cli/src/info.rs
@@ -63,6 +63,19 @@ pub fn handle_info(args: InfoArgs) -> Result<()> {
         }
     }
 
+    match image.raw_exif_data() {
+        Ok(None) => {}
+        Ok(Some(exif)) => {
+            if let Some(data) = exif.payload() {
+                let size = data.len();
+                println!("Exif metadata: {size} byte(s)");
+            }
+        }
+        Err(e) => {
+            println!("Invalid Exif metadata: {e}");
+        }
+    }
+
     if let Some(animation) = &image_meta.animation {
         println!(
             "  Animated ({}/{} ticks per second)",

--- a/crates/jxl-oxide/Cargo.toml
+++ b/crates/jxl-oxide/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.11.0"
 edition = "2021"
 
 [dependencies]
+brotli-decompressor = "4.0.1"
 tracing.workspace = true
 
 [dependencies.bytemuck]

--- a/crates/jxl-oxide/examples/image-integration.rs
+++ b/crates/jxl-oxide/examples/image-integration.rs
@@ -16,6 +16,13 @@ fn main() {
 
     #[allow(unused)]
     let icc = decoder.icc_profile().unwrap();
+    let exif = decoder
+        .exif_metadata()
+        .expect("cannot decode Exif metadata");
+    if let Some(exif) = exif {
+        println!("Exif metadata found ({} byte(s))", exif.len());
+    }
+
     let image = DynamicImage::from_decoder(decoder).expect("cannot decode image");
 
     let output_file = std::fs::File::create(output_path).expect("cannot open output file");

--- a/crates/jxl-oxide/src/aux_box.rs
+++ b/crates/jxl-oxide/src/aux_box.rs
@@ -1,0 +1,153 @@
+use std::io::Write;
+
+use brotli_decompressor::DecompressorWriter;
+
+use crate::Result;
+
+mod exif;
+
+pub use exif::*;
+
+#[derive(Debug, Default)]
+pub struct AuxBoxReader {
+    data: DataKind,
+    done: bool,
+}
+
+#[derive(Default)]
+enum DataKind {
+    #[default]
+    Init,
+    NoData,
+    Raw(Vec<u8>),
+    Brotli(Box<DecompressorWriter<Vec<u8>>>),
+}
+
+impl std::fmt::Debug for DataKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Init => write!(f, "Init"),
+            Self::NoData => write!(f, "NoData"),
+            Self::Raw(buf) => f
+                .debug_tuple("Raw")
+                .field(&format_args!("{} byte(s)", buf.len()))
+                .finish(),
+            Self::Brotli(_) => f.debug_tuple("Brotli").finish(),
+        }
+    }
+}
+
+impl AuxBoxReader {
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(super) fn ensure_brotli(&mut self) -> Result<()> {
+        if self.done {
+            return Ok(());
+        }
+
+        match self.data {
+            DataKind::Init => {
+                let writer = DecompressorWriter::new(Vec::<u8>::new(), 4096);
+                self.data = DataKind::Brotli(Box::new(writer));
+            }
+            DataKind::NoData | DataKind::Raw(_) => {
+                panic!();
+            }
+            DataKind::Brotli(_) => {}
+        }
+        Ok(())
+    }
+}
+
+impl AuxBoxReader {
+    pub fn feed_data(&mut self, data: &[u8]) -> Result<()> {
+        if self.done {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "cannot feed into finalized box",
+            )
+            .into());
+        }
+
+        match self.data {
+            DataKind::Init => {
+                self.data = DataKind::Raw(data.to_vec());
+            }
+            DataKind::NoData => {
+                unreachable!();
+            }
+            DataKind::Raw(ref mut buf) => {
+                buf.extend_from_slice(data);
+            }
+            DataKind::Brotli(ref mut writer) => {
+                writer.write_all(data)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn finalize(&mut self) -> Result<()> {
+        if self.done {
+            return Ok(());
+        }
+
+        if let DataKind::Brotli(ref mut writer) = self.data {
+            writer.flush()?;
+            writer.close()?;
+        }
+
+        match std::mem::replace(&mut self.data, DataKind::NoData) {
+            DataKind::Init | DataKind::NoData => {}
+            DataKind::Raw(buf) => self.data = DataKind::Raw(buf),
+            DataKind::Brotli(writer) => {
+                let inner = writer.into_inner().inspect_err(|_| {
+                    tracing::warn!("Brotli decompressor reported an error");
+                });
+                let buf = inner.unwrap_or_else(|buf| buf);
+                self.data = DataKind::Raw(buf);
+            }
+        }
+
+        self.done = true;
+        Ok(())
+    }
+}
+
+impl AuxBoxReader {
+    pub fn is_done(&self) -> bool {
+        self.done
+    }
+
+    pub fn data(&self) -> AuxBoxData {
+        if !self.is_done() {
+            return AuxBoxData::Decoding;
+        }
+
+        match &self.data {
+            DataKind::Init | DataKind::Brotli(_) => AuxBoxData::Decoding,
+            DataKind::NoData => AuxBoxData::NotFound,
+            DataKind::Raw(buf) => AuxBoxData::Data(buf),
+        }
+    }
+}
+
+pub enum AuxBoxData<'data> {
+    Data(&'data [u8]),
+    Decoding,
+    NotFound,
+}
+
+impl std::fmt::Debug for AuxBoxData<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Data(buf) => f
+                .debug_tuple("Data")
+                .field(&format_args!("{} byte(s)", buf.len()))
+                .finish(),
+            Self::Decoding => write!(f, "Decoding"),
+            Self::NotFound => write!(f, "NotFound"),
+        }
+    }
+}

--- a/crates/jxl-oxide/src/aux_box/exif.rs
+++ b/crates/jxl-oxide/src/aux_box/exif.rs
@@ -1,0 +1,64 @@
+use crate::Result;
+
+/// Raw Exif metadata.
+pub struct RawExif<'image> {
+    tiff_header_offset: u32,
+    payload: Option<&'image [u8]>,
+}
+
+impl std::fmt::Debug for RawExif<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RawExif")
+            .field("tiff_header_offset", &self.tiff_header_offset)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'image> RawExif<'image> {
+    pub(crate) fn empty() -> Self {
+        Self {
+            tiff_header_offset: 0,
+            payload: None,
+        }
+    }
+
+    pub(crate) fn new(box_data: &'image [u8]) -> Result<Self> {
+        if box_data.len() < 4 {
+            tracing::error!(len = box_data.len(), "Exif box is too short");
+            return Err(jxl_bitstream::Error::ValidationFailed("Exif box is too short").into());
+        }
+
+        let (tiff, payload) = box_data.split_at(4);
+        let tiff_header_offset = u32::from_be_bytes([tiff[0], tiff[1], tiff[2], tiff[3]]);
+        if tiff_header_offset as usize >= payload.len() {
+            tracing::error!(
+                payload_len = payload.len(),
+                tiff_header_offset,
+                "tiff_header_offset of Exif box is too large"
+            );
+            return Err(jxl_bitstream::Error::ValidationFailed(
+                "tiff_header_offset of Exif box is too large",
+            )
+            .into());
+        }
+
+        Ok(Self {
+            tiff_header_offset,
+            payload: Some(payload),
+        })
+    }
+}
+
+impl<'image> RawExif<'image> {
+    /// Returns the offset of TIFF header within the payload.
+    pub fn tiff_header_offset(&self) -> u32 {
+        self.tiff_header_offset
+    }
+
+    /// Returns the payload, if exists.
+    ///
+    /// Returns `None` if Exif metadata wasn't found in the image.
+    pub fn payload(&self) -> Option<&'image [u8]> {
+        self.payload
+    }
+}


### PR DESCRIPTION
Added `brotli-decompressor` as a dependency of `jxl-oxide`.

Resolves #381 