### PR TITLE
jxl-threadpool: Add `rayon_global`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `jxl-threadpool`: Add `rayon_global` (#420).
+
+### Changed
+- `jxl-oxide`: Default thread pool now uses global Rayon pool, instead of creating new pool (#420).
+
 ## [0.11.1] - 2025-01-25
 
 ### Fixed

--- a/crates/jxl-oxide-cli/src/commands/decode.rs
+++ b/crates/jxl-oxide-cli/src/commands/decode.rs
@@ -67,8 +67,8 @@ pub struct DecodeArgs {
     #[arg(long)]
     pub target_icc: Option<PathBuf>,
     /// Number of parallelism to use
-    #[cfg(feature = "rayon")]
-    #[arg(short = 'j', long)]
+    #[cfg_attr(feature = "rayon", arg(short = 'j', long))]
+    #[cfg_attr(not(feature = "rayon"), arg(skip))]
     pub num_threads: Option<usize>,
     /// Number of repeated decoding, used for benchmarking
     #[arg(long, value_parser = clap::value_parser!(u32).range(1..))]

--- a/crates/jxl-oxide-cli/src/commands/progressive.rs
+++ b/crates/jxl-oxide-cli/src/commands/progressive.rs
@@ -17,8 +17,8 @@ pub struct ProgressiveArgs {
     #[arg(short, long)]
     pub output: Option<PathBuf>,
     /// Number of parallelism to use
-    #[cfg(feature = "rayon")]
-    #[arg(short = 'j', long)]
+    #[cfg_attr(feature = "rayon", arg(short = 'j', long))]
+    #[cfg_attr(not(feature = "rayon"), arg(skip))]
     pub num_threads: Option<usize>,
     /// Font to use when displaying frame info
     #[cfg(feature = "__ffmpeg")]

--- a/crates/jxl-oxide-cli/src/commands/slow_motion.rs
+++ b/crates/jxl-oxide-cli/src/commands/slow_motion.rs
@@ -14,8 +14,8 @@ pub struct SlowMotionArgs {
     #[arg(short = 'b', long, value_parser = value_parser!(u32).range(1..=1024), default_value_t = 1)]
     pub bytes_per_frame: u32,
     /// Number of parallelism to use
-    #[cfg(feature = "rayon")]
-    #[arg(short = 'j', long)]
+    #[cfg_attr(feature = "rayon", arg(short = 'j', long))]
+    #[cfg_attr(not(feature = "rayon"), arg(skip))]
     pub num_threads: Option<usize>,
     /// Font to use when displaying frame info
     #[arg(long, default_value_t = String::from("monospace"))]

--- a/crates/jxl-oxide-cli/src/decode.rs
+++ b/crates/jxl-oxide-cli/src/decode.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use jxl_oxide::{AllocTracker, CropInfo, EnumColourEncoding, JxlImage, JxlThreadPool, Render};
+use jxl_oxide::{AllocTracker, CropInfo, EnumColourEncoding, JxlImage, Render};
 
 use crate::commands::decode::*;
 use crate::{output, Error, Result};
@@ -8,10 +8,7 @@ use crate::{output, Error, Result};
 pub fn handle_decode(args: DecodeArgs) -> Result<()> {
     let _guard = tracing::trace_span!("Handle decode subcommand").entered();
 
-    #[cfg(feature = "rayon")]
-    let pool = JxlThreadPool::rayon(args.num_threads);
-    #[cfg(not(feature = "rayon"))]
-    let pool = JxlThreadPool::none();
+    let pool = crate::create_thread_pool(args.num_threads);
 
     let mut image_builder = JxlImage::builder().pool(pool.clone());
     if args.approx_memory_limit != 0 {

--- a/crates/jxl-oxide-cli/src/lib.rs
+++ b/crates/jxl-oxide-cli/src/lib.rs
@@ -17,3 +17,18 @@ pub use commands::{Args, Subcommands};
 pub use error::Error;
 
 type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(feature = "rayon")]
+fn create_thread_pool(num_threads: Option<usize>) -> jxl_oxide::JxlThreadPool {
+    if num_threads.is_some() {
+        jxl_oxide::JxlThreadPool::rayon(num_threads)
+    } else {
+        tracing::debug!("Using default number of threads");
+        jxl_oxide::JxlThreadPool::rayon_global()
+    }
+}
+
+#[cfg(not(feature = "rayon"))]
+fn create_thread_pool(_num_threads: Option<usize>) -> jxl_oxide::JxlThreadPool {
+    jxl_oxide::JxlThreadPool::none()
+}

--- a/crates/jxl-oxide-cli/src/progressive.rs
+++ b/crates/jxl-oxide-cli/src/progressive.rs
@@ -1,7 +1,7 @@
 use std::io::prelude::*;
 use std::path::Path;
 
-use jxl_oxide::{JxlImage, JxlThreadPool, Render};
+use jxl_oxide::{JxlImage, Render};
 
 use crate::commands::progressive::*;
 use crate::{Error, Result};
@@ -182,10 +182,7 @@ pub fn handle_progressive(args: ProgressiveArgs) -> Result<()> {
 
     let _guard = tracing::trace_span!("Handle progressive subcommand").entered();
 
-    #[cfg(feature = "rayon")]
-    let pool = JxlThreadPool::rayon(args.num_threads);
-    #[cfg(not(feature = "rayon"))]
-    let pool = JxlThreadPool::none();
+    let pool = crate::create_thread_pool(args.num_threads);
 
     let mut uninit_image = JxlImage::builder().pool(pool.clone()).build_uninit();
 

--- a/crates/jxl-oxide-cli/src/slow_motion.rs
+++ b/crates/jxl-oxide-cli/src/slow_motion.rs
@@ -1,6 +1,6 @@
 use std::io::prelude::*;
 
-use jxl_oxide::{EnumColourEncoding, JxlImage, JxlThreadPool, Render, RenderingIntent};
+use jxl_oxide::{EnumColourEncoding, JxlImage, Render, RenderingIntent};
 
 use crate::commands::slow_motion::*;
 use crate::output::Mp4FileEncoder;
@@ -61,10 +61,7 @@ impl std::fmt::Display for LoadProgress {
 pub fn handle_slow_motion(args: SlowMotionArgs) -> Result<()> {
     let _guard = tracing::trace_span!("Handle slow-motion subcommand").entered();
 
-    #[cfg(feature = "rayon")]
-    let pool = JxlThreadPool::rayon(args.num_threads);
-    #[cfg(not(feature = "rayon"))]
-    let pool = JxlThreadPool::none();
+    let pool = crate::create_thread_pool(args.num_threads);
 
     let bytes_per_frame = args.bytes_per_frame as usize;
 

--- a/crates/jxl-oxide-tests/benches/decode.rs
+++ b/crates/jxl-oxide-tests/benches/decode.rs
@@ -12,7 +12,7 @@ fn decode(c: &mut Criterion) {
     bench_path.push("decode/benchmark-data");
 
     #[cfg(feature = "rayon")]
-    let pool = JxlThreadPool::rayon(None);
+    let pool = JxlThreadPool::rayon_global();
     #[cfg(not(feature = "rayon"))]
     let pool = JxlThreadPool::none();
 

--- a/crates/jxl-oxide/src/lib.rs
+++ b/crates/jxl-oxide/src/lib.rs
@@ -184,7 +184,7 @@ pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + S
 
 #[cfg(feature = "rayon")]
 fn default_pool() -> JxlThreadPool {
-    JxlThreadPool::rayon(None)
+    JxlThreadPool::rayon_global()
 }
 
 #[cfg(not(feature = "rayon"))]


### PR DESCRIPTION
Add an option to use global Rayon thread pool.

Using multiple thread pools simultaneously seems to cause stack overflow in some cases: https://github.com/rayon-rs/rayon/issues/751. `JxlThreadPool::rayon_global` helps working around the issue by using single global thread pool.