### PR TITLE
Add image dimensions to jxl-oxide-wasm

### DIFF
--- a/crates/jxl-oxide-wasm/src/lib.rs
+++ b/crates/jxl-oxide-wasm/src/lib.rs
@@ -148,6 +148,22 @@ impl WasmJxlImage {
         }
     }
 
+    #[wasm_bindgen(getter = width)]
+    pub fn width(&self) -> Option<u32> {
+        match &self.inner {
+            WasmJxlImageInner::Uninit(_) => None,
+            WasmJxlImageInner::Init(image) => Some(image.width()),
+        }
+    }
+
+    #[wasm_bindgen(getter = height)]
+    pub fn height(&self) -> Option<u32> {
+        match &self.inner {
+            WasmJxlImageInner::Uninit(_) => None,
+            WasmJxlImageInner::Init(image) => Some(image.height()),
+        }
+    }
+
     #[wasm_bindgen(getter = numLoops)]
     pub fn num_loops(&self) -> Option<u32> {
         match &self.inner {


### PR DESCRIPTION
Thanks for making this library! I've been using it for my [VS Code extension](https://github.com/printfn/jpeg-xl-vscode).

I noticed that `jxl-oxide-wasm` doesn't expose the width and height of the image, so I thought it'd be nice if it was more easily available since I'm currently having to manually parse the PNG header to extract this info.