### PR TITLE
jxl-jbr: Fix dimension aligning of subsampled JPEG

### DIFF
--- a/crates/jxl-jbr/src/reconstruct.rs
+++ b/crates/jxl-jbr/src/reconstruct.rs
@@ -199,9 +199,9 @@ impl<'jbrd, 'frame, 'meta> JpegBitstreamReconstructor<'jbrd, 'frame, 'meta> {
             let (w, h) = frame_header.group_size_for(group_idx);
 
             pass_groups.push(upsampling_shifts_ycbcr.map(|shift| {
-                let (w, h) = shift.shift_size((w, h));
-                let w = (w + 7) & !7;
-                let h = (h + 7) & !7;
+                let (w8, h8) = shift.shift_size((w.div_ceil(8), h.div_ceil(8)));
+                let w = w8 * 8;
+                let h = h8 * 8;
                 AlignedGrid::<i32>::with_alloc_tracker(w as usize, h as usize, None).unwrap()
             }));
         }

--- a/crates/jxl-render/src/vardct/mod.rs
+++ b/crates/jxl-render/src/vardct/mod.rs
@@ -204,7 +204,9 @@ pub(crate) fn render_vardct<S: Sample>(
 
             let mut fb = ImageWithRegion::new(3, tracker);
             for shift in shifts_cbycr {
-                let (width, height) = shift.shift_size((width, height));
+                let (w8, h8) = shift.shift_size((width.div_ceil(8), height.div_ceil(8)));
+                let width = w8 * 8;
+                let height = h8 * 8;
                 let buffer =
                     AlignedGrid::with_alloc_tracker(width as usize, height as usize, tracker)?;
                 fb.append_channel_shifted(ImageBuffer::F32(buffer), modular_region, shift);


### PR DESCRIPTION
HF coeff buffers were not being aligned properly. They should be aligned according to 8x8 varblock units.

Fixes #425 