### PR TITLE
Upgrade to Rust 2024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,12 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,11 +109,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
@@ -151,10 +146,10 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide 0.8.2",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -169,7 +164,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -191,15 +186,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -207,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byte-slice-cast"
@@ -219,15 +214,9 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "byteorder-lite"
@@ -237,9 +226,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "camino"
@@ -255,9 +244,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.6"
+version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333"
+checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "jobserver",
  "libc",
@@ -339,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -349,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -361,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -481,9 +470,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "displaydoc"
@@ -504,9 +493,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "fdeflate"
@@ -519,12 +508,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -628,7 +617,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -640,15 +643,15 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -662,15 +665,15 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -689,12 +692,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "pin-project-lite",
@@ -702,15 +705,15 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -745,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -755,6 +758,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -764,14 +768,15 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -826,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
@@ -850,9 +855,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
 name = "icu_properties"
@@ -871,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_provider"
@@ -926,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.5"
+version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6f44aed642f18953a158afeb30206f4d50da59fbc66ecb53c66488de73563b"
+checksum = "db35664ce6b9810857a38a906215e75a9c879f0696556a39f59c62829710251a"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -938,19 +943,19 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -979,24 +984,25 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.2",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1120,7 +1126,7 @@ dependencies = [
  "jxl-oxide",
  "lcms2",
  "mimalloc",
- "miniz_oxide 0.8.2",
+ "miniz_oxide",
  "png",
  "rayon",
  "rusty_ffmpeg",
@@ -1166,7 +1172,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "jxl-oxide",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
  "png",
  "wasm-bindgen",
  "web-sys",
@@ -1243,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libloading"
@@ -1254,14 +1260,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.39"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+checksum = "6b20daca3a4ac14dbdc753c5e90fc7b490a48a9131daed3c9a9ced7b2defd37b"
 dependencies = [
  "cc",
  "libc",
@@ -1269,15 +1275,15 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "matchers"
@@ -1296,9 +1302,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mimalloc"
-version = "0.1.43"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+checksum = "03cb1f88093fe50061ca1195d336ffec131347c7b833db31f9ab62a2d1b7925f"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -1317,18 +1323,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -1341,15 +1338,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "moxcms"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce11a19b7b154934b7b8ec846a730eccd29859eeb12c1461e1b33d40b372ca46"
+checksum = "ef5cbbb08b708abf222897b245cb1a1e4877d6c403cf2e7aa618efaf0390a0bc"
 dependencies = [
  "chrono",
  "num-traits",
@@ -1436,15 +1433,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
-version = "11.1.4"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "overload"
@@ -1460,9 +1457,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -1472,9 +1469,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -1514,23 +1511,23 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide 0.8.2",
+ "miniz_oxide",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
 
 [[package]]
 name = "prettyplease"
-version = "0.2.25"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1538,42 +1535,44 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quinn"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
 dependencies = [
  "bytes",
+ "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2",
  "thiserror",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
 dependencies = [
  "bytes",
- "getrandom",
+ "getrandom 0.3.2",
  "rand",
  "ring",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -1585,9 +1584,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
+checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1599,29 +1598,35 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
+ "zerocopy",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -1629,11 +1634,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -1702,9 +1707,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.10"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3536321cfc54baa8cf3e273d5e1f63f889067829c4b410fcdbac8ca7b80994"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64",
  "bytes",
@@ -1746,15 +1751,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -1773,15 +1777,15 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustls"
-version = "0.23.20"
+version = "0.23.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
  "once_cell",
  "ring",
@@ -1802,23 +1806,29 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 dependencies = [
  "web-time",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
  "ring",
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "rusty_ffmpeg"
@@ -1836,9 +1846,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -1851,18 +1861,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1871,9 +1881,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.134"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -1925,25 +1935,19 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "ssimulacra2"
@@ -1978,9 +1982,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.92"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ae51629bf965c5c098cc9e87908a3df5301051a9e087d6f9bef5c9771ed126"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2009,18 +2013,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2059,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2074,9 +2078,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2089,9 +2093,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
  "tokio",
@@ -2181,9 +2185,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "untrusted"
@@ -2239,9 +2243,9 @@ checksum = "153b41c3fc24dcbdf1281fc2b93d5d67ef2ef73ccd0e3b1d6bef2ce4861cce15"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -2275,21 +2279,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.99"
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -2301,9 +2315,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2314,9 +2328,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2324,9 +2338,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2337,15 +2351,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2363,9 +2380,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2403,11 +2420,37 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-targets",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings 0.4.0",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2418,32 +2461,40 @@ checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-registry"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
- "windows-strings",
- "windows-targets",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result",
- "windows-targets",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2452,7 +2503,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2461,7 +2512,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2470,14 +2521,30 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -2487,10 +2554,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2499,10 +2578,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2511,10 +2602,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2523,10 +2626,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.0",
+]
 
 [[package]]
 name = "write16"
@@ -2585,19 +2709,18 @@ checksum = "453f24cf9e21be2148954a438c72fb999da42b1d128105bfd73ce91e1c6c7d33"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2606,18 +2729,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2655,27 +2778,27 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.1"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.15+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,6 +1030,7 @@ dependencies = [
  "jxl-bitstream",
  "jxl-coding",
  "jxl-grid",
+ "jxl-image",
  "jxl-oxide-common",
  "jxl-threadpool",
  "tracing",
@@ -1062,7 +1063,6 @@ name = "jxl-image"
 version = "0.13.0"
 dependencies = [
  "jxl-bitstream",
- "jxl-color",
  "jxl-grid",
  "jxl-oxide-common",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,14 +1010,14 @@ dependencies = [
 
 [[package]]
 name = "jxl-bitstream"
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "jxl-coding"
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "jxl-bitstream",
  "tracing",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "jxl-grid"
-version = "0.5.3"
+version = "1.0.0-alpha.0"
 dependencies = [
  "tracing",
 ]
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "jxl-modular"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "jxl-oxide-common"
-version = "0.2.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "jxl-bitstream",
 ]
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "jxl-threadpool"
-version = "0.1.2"
+version = "1.0.0-alpha.0"
 dependencies = [
  "rayon",
  "rayon-core",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "jxl-vardct"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",

--- a/crates/jxl-bitstream/Cargo.toml
+++ b/crates/jxl-bitstream/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jpeg-xl", "decoder", "jxl-oxide"]
 categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/jxl-bitstream/Cargo.toml
+++ b/crates/jxl-bitstream/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
 version = "0.6.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 tracing.workspace = true

--- a/crates/jxl-bitstream/src/container/box_header.rs
+++ b/crates/jxl-bitstream/src/container/box_header.rs
@@ -19,6 +19,7 @@ pub enum HeaderParseResult {
 impl ContainerBoxHeader {
     pub(super) fn parse(buf: &[u8]) -> Result<HeaderParseResult, Error> {
         let (tbox, box_size, header_size) = match *buf {
+            #[rustfmt::skip]
             [0, 0, 0, 1, t0, t1, t2, t3, s0, s1, s2, s3, s4, s5, s6, s7, ..] => {
                 let xlbox = u64::from_be_bytes([s0, s1, s2, s3, s4, s5, s6, s7]);
                 let tbox = ContainerBoxType([t0, t1, t2, t3]);

--- a/crates/jxl-bitstream/src/lib.rs
+++ b/crates/jxl-bitstream/src/lib.rs
@@ -5,7 +5,7 @@ mod bitstream;
 pub mod container;
 mod error;
 
-pub use bitstream::{Bitstream, U32Specifier, U};
+pub use bitstream::{Bitstream, U, U32Specifier};
 pub use container::{BitstreamKind, ContainerDetectingReader, ParseEvent};
 pub use error::{Error, Result};
 

--- a/crates/jxl-coding/Cargo.toml
+++ b/crates/jxl-coding/Cargo.toml
@@ -8,12 +8,12 @@ keywords = ["jpeg-xl", "decoder", "jxl-oxide"]
 categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 edition = "2024"
 
 [dependencies]
 tracing.workspace = true
 
 [dependencies.jxl-bitstream]
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-bitstream"

--- a/crates/jxl-coding/Cargo.toml
+++ b/crates/jxl-coding/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
 version = "0.6.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 tracing.workspace = true

--- a/crates/jxl-coding/src/error.rs
+++ b/crates/jxl-coding/src/error.rs
@@ -42,7 +42,11 @@ impl std::fmt::Display for Error {
                 split_exponent,
                 msb_in_token,
                 lsb_in_token,
-            } => write!(f, "invalid hybrid integer configuration; {} + {msb_in_token} > {split_exponent}", lsb_in_token.unwrap_or(0)),
+            } => write!(
+                f,
+                "invalid hybrid integer configuration; {} + {msb_in_token} > {split_exponent}",
+                lsb_in_token.unwrap_or(0)
+            ),
             Self::InvalidPermutation => write!(f, "invalid permutation"),
             Self::InvalidPrefixHistogram => write!(f, "invalid Brotli prefix code"),
             Self::PrefixSymbolTooLarge(size) => write!(f, "prefix code symbol too large ({size})"),
@@ -50,7 +54,10 @@ impl std::fmt::Display for Error {
             Self::ClusterHole {
                 num_expected_clusters,
                 num_actual_clusters,
-            } => write!(f, "distribution cluster has a hole; expected {num_expected_clusters}, actual {num_actual_clusters}"),
+            } => write!(
+                f,
+                "distribution cluster has a hole; expected {num_expected_clusters}, actual {num_actual_clusters}"
+            ),
             Self::UnexpectedLz77Repeat => write!(
                 f,
                 "LZ77 repeat symbol encountered without decoding any symbols"

--- a/crates/jxl-coding/src/prefix.rs
+++ b/crates/jxl-coding/src/prefix.rs
@@ -350,11 +350,13 @@ impl Histogram {
 
     #[inline]
     pub fn single_symbol(&self) -> Option<u32> {
-        if let &[Entry {
-            nested: false,
-            bits_or_mask: 0,
-            symbol_or_offset: symbol,
-        }] = &*self.toplevel_entries
+        if let &[
+            Entry {
+                nested: false,
+                bits_or_mask: 0,
+                symbol_or_offset: symbol,
+            },
+        ] = &*self.toplevel_entries
         {
             Some(symbol as u32)
         } else {

--- a/crates/jxl-color/Cargo.toml
+++ b/crates/jxl-color/Cargo.toml
@@ -26,6 +26,10 @@ path = "../jxl-coding"
 version = "1.0.0-alpha.0"
 path = "../jxl-grid"
 
+[dependencies.jxl-image]
+version = "0.13.0"
+path = "../jxl-image"
+
 [dependencies.jxl-oxide-common]
 version = "1.0.0-alpha.0"
 path = "../jxl-oxide-common"

--- a/crates/jxl-color/Cargo.toml
+++ b/crates/jxl-color/Cargo.toml
@@ -15,21 +15,21 @@ edition = "2024"
 tracing.workspace = true
 
 [dependencies.jxl-bitstream]
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-bitstream"
 
 [dependencies.jxl-coding]
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-coding"
 
 [dependencies.jxl-grid]
-version = "0.5.3"
+version = "1.0.0-alpha.0"
 path = "../jxl-grid"
 
 [dependencies.jxl-oxide-common]
-version = "0.2.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-oxide-common"
 
 [dependencies.jxl-threadpool]
-version = "0.1.1"
+version = "1.0.0-alpha.0"
 path = "../jxl-threadpool"

--- a/crates/jxl-color/Cargo.toml
+++ b/crates/jxl-color/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
 version = "0.11.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 tracing.workspace = true

--- a/crates/jxl-color/src/convert.rs
+++ b/crates/jxl-color/src/convert.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
 use crate::{
-    ciexyz::*, consts::*, icc::colour_encoding_to_icc, tf, ColorManagementSystem, ColourEncoding,
-    ColourSpace, EnumColourEncoding, Error, OpsinInverseMatrix, PreparedTransform, RenderingIntent,
-    Result, ToneMapping, TransferFunction,
+    ColorManagementSystem, ColourEncoding, ColourSpace, EnumColourEncoding, Error,
+    OpsinInverseMatrix, PreparedTransform, RenderingIntent, Result, ToneMapping, TransferFunction,
+    ciexyz::*, consts::*, icc::colour_encoding_to_icc, tf,
 };
 
 mod gamut_map;

--- a/crates/jxl-color/src/header.rs
+++ b/crates/jxl-color/src/header.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::excessive_precision)]
 use jxl_bitstream::{Bitstream, Error, Result};
-use jxl_oxide_common::{define_bundle, Bundle};
+use jxl_oxide_common::{Bundle, define_bundle};
 
 use crate::consts::*;
 

--- a/crates/jxl-color/src/icc/decode.rs
+++ b/crates/jxl-color/src/icc/decode.rs
@@ -1,5 +1,5 @@
-use std::io::prelude::*;
 use std::io::Cursor;
+use std::io::prelude::*;
 
 use jxl_bitstream::Bitstream;
 

--- a/crates/jxl-color/src/icc/parse.rs
+++ b/crates/jxl-color/src/icc/parse.rs
@@ -536,7 +536,7 @@ pub(crate) fn parse_icc(profile: &[u8]) -> Result<EnumColourEncoding> {
         };
         let wp = info.white_point();
         Ok(EnumColourEncoding {
-            colour_space: crate::ColourSpace::Grey,
+            colour_space: ColourSpace::Grey,
             white_point: wp,
             primaries: Primaries::Srgb,
             tf,
@@ -548,7 +548,7 @@ pub(crate) fn parse_icc(profile: &[u8]) -> Result<EnumColourEncoding> {
         };
         let wp = info.white_point();
         Ok(EnumColourEncoding {
-            colour_space: crate::ColourSpace::Rgb,
+            colour_space: ColourSpace::Rgb,
             white_point: wp,
             primaries,
             tf,

--- a/crates/jxl-color/src/icc/synthesize.rs
+++ b/crates/jxl-color/src/icc/synthesize.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ciexyz::*, consts::*, tf, ColourSpace, EnumColourEncoding, Primaries, RenderingIntent,
-    TransferFunction, WhitePoint,
+    ColourSpace, EnumColourEncoding, Primaries, RenderingIntent, TransferFunction, WhitePoint,
+    ciexyz::*, consts::*, tf,
 };
 
 use super::IccTag;

--- a/crates/jxl-color/src/lib.rs
+++ b/crates/jxl-color/src/lib.rs
@@ -18,14 +18,15 @@ mod convert;
 mod error;
 mod fastmath;
 mod gamut;
-pub mod header;
 pub mod icc;
 mod tf;
 mod xyb;
 mod ycbcr;
 
+pub use jxl_image::color::*;
+
+pub use ciexyz::{AsIlluminant, AsPrimaries};
 pub use cms::*;
 pub use convert::*;
 pub use error::*;
-pub use header::*;
 pub use ycbcr::ycbcr_to_rgb;

--- a/crates/jxl-color/src/lib.rs
+++ b/crates/jxl-color/src/lib.rs
@@ -9,6 +9,7 @@
 //! # Modules
 //! - [`consts`] defines constants used by the various colorspaces.
 //! - [`icc`] provides functions related to ICC profiles.
+#![allow(unsafe_op_in_unsafe_fn)]
 
 mod ciexyz;
 mod cms;

--- a/crates/jxl-frame/Cargo.toml
+++ b/crates/jxl-frame/Cargo.toml
@@ -15,15 +15,15 @@ edition = "2024"
 tracing.workspace = true
 
 [dependencies.jxl-bitstream]
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-bitstream"
 
 [dependencies.jxl-coding]
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-coding"
 
 [dependencies.jxl-grid]
-version = "0.5.3"
+version = "1.0.0-alpha.0"
 path = "../jxl-grid"
 
 [dependencies.jxl-image]
@@ -31,17 +31,17 @@ version = "0.13.0"
 path = "../jxl-image"
 
 [dependencies.jxl-modular]
-version = "0.10.0"
+version = "0.11.0"
 path = "../jxl-modular"
 
 [dependencies.jxl-oxide-common]
-version = "0.2.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-oxide-common"
 
 [dependencies.jxl-threadpool]
-version = "0.1.1"
+version = "1.0.0-alpha.0"
 path = "../jxl-threadpool"
 
 [dependencies.jxl-vardct]
-version = "0.10.1"
+version = "0.11.0"
 path = "../jxl-vardct"

--- a/crates/jxl-frame/Cargo.toml
+++ b/crates/jxl-frame/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
 version = "0.13.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 tracing.workspace = true

--- a/crates/jxl-frame/src/data/lf_global.rs
+++ b/crates/jxl-frame/src/data/lf_global.rs
@@ -4,10 +4,10 @@ use jxl_image::ImageHeader;
 use jxl_modular::{
     ChannelShift, MaConfig, MaConfigParams, Modular, ModularChannelParams, ModularParams, Sample,
 };
-use jxl_oxide_common::{define_bundle, Bundle};
+use jxl_oxide_common::{Bundle, define_bundle};
 use jxl_vardct::{HfBlockContext, LfChannelCorrelation, LfChannelDequantization, Quantizer};
 
-use crate::{header::Encoding, FrameHeader, Result};
+use crate::{FrameHeader, Result, header::Encoding};
 
 use super::{NoiseParameters, Patches, Splines};
 

--- a/crates/jxl-frame/src/data/lf_group.rs
+++ b/crates/jxl-frame/src/data/lf_group.rs
@@ -1,13 +1,13 @@
 use jxl_bitstream::Bitstream;
 use jxl_grid::AllocTracker;
-use jxl_modular::{image::TransformedModularSubimage, MaConfig, Sample};
+use jxl_modular::{MaConfig, Sample, image::TransformedModularSubimage};
 use jxl_oxide_common::Bundle;
 use jxl_vardct::{HfMetadata, HfMetadataParams, LfCoeff, LfCoeffParams, Quantizer};
 
 use crate::{
+    FrameHeader, Result,
     filter::{EdgePreservingFilter, EpfParams},
     header::Encoding,
-    FrameHeader, Result,
 };
 
 #[derive(Debug)]

--- a/crates/jxl-frame/src/data/pass_group.rs
+++ b/crates/jxl-frame/src/data/pass_group.rs
@@ -2,9 +2,9 @@ use std::sync::atomic::AtomicI32;
 
 use jxl_bitstream::Bitstream;
 use jxl_grid::{AllocTracker, SharedSubgrid};
-use jxl_modular::{image::TransformedModularSubimage, ChannelShift, MaConfig, Sample};
+use jxl_modular::{ChannelShift, MaConfig, Sample, image::TransformedModularSubimage};
 use jxl_threadpool::JxlThreadPool;
-use jxl_vardct::{write_hf_coeff, HfCoeffParams};
+use jxl_vardct::{HfCoeffParams, write_hf_coeff};
 
 use super::{HfGlobal, LfGlobalVarDct, LfGroup};
 use crate::{FrameHeader, Result};

--- a/crates/jxl-frame/src/data/patch.rs
+++ b/crates/jxl-frame/src/data/patch.rs
@@ -1,4 +1,4 @@
-use jxl_bitstream::{unpack_signed, Bitstream};
+use jxl_bitstream::{Bitstream, unpack_signed};
 use jxl_image::ImageHeader;
 use jxl_oxide_common::Bundle;
 
@@ -65,7 +65,7 @@ impl TryFrom<u32> for PatchBlendMode {
                 return Err(jxl_bitstream::Error::InvalidEnum {
                     name: "PatchBlendMode",
                     value,
-                })
+                });
             }
         })
     }

--- a/crates/jxl-frame/src/data/spline.rs
+++ b/crates/jxl-frame/src/data/spline.rs
@@ -1,4 +1,4 @@
-use jxl_bitstream::{unpack_signed, Bitstream};
+use jxl_bitstream::{Bitstream, unpack_signed};
 use jxl_coding::Decoder;
 use jxl_oxide_common::Bundle;
 

--- a/crates/jxl-frame/src/filter.rs
+++ b/crates/jxl-frame/src/filter.rs
@@ -1,7 +1,7 @@
 use jxl_bitstream::Bitstream;
 use jxl_oxide_common::Bundle;
 
-use crate::{header::Encoding, Result};
+use crate::{Result, header::Encoding};
 
 #[derive(Debug, Clone)]
 pub enum Gabor {

--- a/crates/jxl-frame/src/header.rs
+++ b/crates/jxl-frame/src/header.rs
@@ -1,7 +1,7 @@
 use crate::Result;
 use jxl_bitstream::{Bitstream, U};
 use jxl_image::{BitDepth, Extensions, ImageHeader, SizeHeader};
-use jxl_oxide_common::{define_bundle, Bundle, Name};
+use jxl_oxide_common::{Bundle, Name, define_bundle};
 
 define_bundle! {
     /// Frame header.
@@ -506,7 +506,7 @@ impl<Ctx> Bundle<Ctx> for BlendMode {
                     name: "BlendMode",
                     value,
                 }
-                .into())
+                .into());
             }
         })
     }

--- a/crates/jxl-frame/src/lib.rs
+++ b/crates/jxl-frame/src/lib.rs
@@ -17,8 +17,8 @@
 //! [`num_groups`]: FrameHeader::num_groups
 //! [`num_passes`]: header::Passes::num_passes
 use std::collections::BTreeMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use jxl_bitstream::Bitstream;
 use jxl_grid::{AllocHandle, AllocTracker};
@@ -33,7 +33,7 @@ pub mod header;
 pub use error::{Error, Result};
 pub use header::FrameHeader;
 use jxl_modular::Sample;
-use jxl_modular::{image::TransformedModularSubimage, MaConfig};
+use jxl_modular::{MaConfig, image::TransformedModularSubimage};
 use jxl_threadpool::JxlThreadPool;
 
 use crate::data::*;

--- a/crates/jxl-grid/Cargo.toml
+++ b/crates/jxl-grid/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
 version = "0.5.3"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 tracing.workspace = true

--- a/crates/jxl-grid/Cargo.toml
+++ b/crates/jxl-grid/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jpeg-xl", "decoder", "jxl-oxide"]
 categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
-version = "0.5.3"
+version = "1.0.0-alpha.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/jxl-grid/src/alloc_tracker.rs
+++ b/crates/jxl-grid/src/alloc_tracker.rs
@@ -1,6 +1,6 @@
 use std::sync::{
-    atomic::{AtomicUsize, Ordering},
     Arc,
+    atomic::{AtomicUsize, Ordering},
 };
 
 /// Allocation tracker with total memory limit.

--- a/crates/jxl-grid/src/mutable_subgrid.rs
+++ b/crates/jxl-grid/src/mutable_subgrid.rs
@@ -116,7 +116,7 @@ impl<'g, V> MutableSubgrid<'g, V> {
     #[inline]
     unsafe fn get_ptr_unchecked(&self, x: usize, y: usize) -> *mut V {
         let offset = y * self.stride + x;
-        self.ptr.as_ptr().add(offset)
+        unsafe { self.ptr.as_ptr().add(offset) }
     }
 
     #[inline]

--- a/crates/jxl-grid/src/simd.rs
+++ b/crates/jxl-grid/src/simd.rs
@@ -1,3 +1,5 @@
+#![allow(unsafe_op_in_unsafe_fn)]
+
 /// Trait representing a SIMD vector.
 pub trait SimdVector: Copy {
     /// The number of `f32` lanes in a single SIMD vector.

--- a/crates/jxl-image/Cargo.toml
+++ b/crates/jxl-image/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2024"
 tracing.workspace = true
 
 [dependencies.jxl-bitstream]
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-bitstream"
 
 [dependencies.jxl-color]
@@ -23,9 +23,9 @@ version = "0.11.0"
 path = "../jxl-color"
 
 [dependencies.jxl-grid]
-version = "0.5.3"
+version = "1.0.0-alpha.0"
 path = "../jxl-grid"
 
 [dependencies.jxl-oxide-common]
-version = "0.2.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-oxide-common"

--- a/crates/jxl-image/Cargo.toml
+++ b/crates/jxl-image/Cargo.toml
@@ -18,10 +18,6 @@ tracing.workspace = true
 version = "1.0.0-alpha.0"
 path = "../jxl-bitstream"
 
-[dependencies.jxl-color]
-version = "0.11.0"
-path = "../jxl-color"
-
 [dependencies.jxl-grid]
 version = "1.0.0-alpha.0"
 path = "../jxl-grid"

--- a/crates/jxl-image/Cargo.toml
+++ b/crates/jxl-image/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
 version = "0.13.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 tracing.workspace = true

--- a/crates/jxl-image/src/color.rs
+++ b/crates/jxl-image/src/color.rs
@@ -4,8 +4,6 @@
 use jxl_bitstream::{Bitstream, Error, Result};
 use jxl_oxide_common::{Bundle, define_bundle};
 
-use crate::consts::*;
-
 /// Color encoding, either represented by enum values, or a signal of existence of ICC profile.
 #[derive(Debug, Clone)]
 pub enum ColourEncoding {
@@ -158,7 +156,8 @@ impl EnumColourEncoding {
         }
     }
 
-    pub(crate) fn srgb_linear(rendering_intent: RenderingIntent) -> Self {
+    /// Creates an sRGB color encoding with linear transfer (instead of sRGB transfer curve).
+    pub fn srgb_linear(rendering_intent: RenderingIntent) -> Self {
         Self {
             colour_space: ColourSpace::Rgb,
             white_point: WhitePoint::D65,
@@ -425,19 +424,6 @@ impl<Ctx> Bundle<Ctx> for WhitePoint {
     }
 }
 
-impl WhitePoint {
-    /// Returns the xy-chromaticity coordinate of the white point as floating point values.
-    #[inline]
-    pub fn as_chromaticity(self) -> [f32; 2] {
-        match self {
-            Self::D65 => ILLUMINANT_D65,
-            Self::Custom(xy) => xy.as_float(),
-            Self::E => ILLUMINANT_E,
-            Self::Dci => ILLUMINANT_DCI,
-        }
-    }
-}
-
 #[derive(Debug, PartialEq, Eq, Default)]
 #[repr(u8)]
 enum PrimariesDiscriminator {
@@ -501,19 +487,6 @@ impl<Ctx> Bundle<Ctx> for Primaries {
 }
 
 impl Primaries {
-    /// Returns the xy-chromaticity coordinates of the primaries as floating point values.
-    #[inline]
-    pub fn as_chromaticity(self) -> [[f32; 2]; 3] {
-        match self {
-            Self::Srgb => PRIMARIES_SRGB,
-            Self::Custom { red, green, blue } => {
-                [red.as_float(), green.as_float(), blue.as_float()]
-            }
-            Self::Bt2100 => PRIMARIES_BT2100,
-            Self::P3 => PRIMARIES_P3,
-        }
-    }
-
     /// Returns the CICP value of the primaries, if there is any.
     pub fn cicp(&self) -> Option<u8> {
         match self {

--- a/crates/jxl-image/src/lib.rs
+++ b/crates/jxl-image/src/lib.rs
@@ -7,7 +7,7 @@
 //! bitstream to retrieve information about the image.
 use jxl_bitstream::{Bitstream, Result, U};
 use jxl_color::header::*;
-use jxl_oxide_common::{define_bundle, Bundle, Name};
+use jxl_oxide_common::{Bundle, Name, define_bundle};
 
 /// JPEG XL image header.
 ///

--- a/crates/jxl-image/src/lib.rs
+++ b/crates/jxl-image/src/lib.rs
@@ -6,8 +6,10 @@
 //! Image header is at the beginning of the bitstream. One can parse [`ImageHeader`] from the
 //! bitstream to retrieve information about the image.
 use jxl_bitstream::{Bitstream, Result, U};
-use jxl_color::header::*;
 use jxl_oxide_common::{Bundle, Name, define_bundle};
+
+pub mod color;
+use color::*;
 
 /// JPEG XL image header.
 ///

--- a/crates/jxl-jbr/Cargo.toml
+++ b/crates/jxl-jbr/Cargo.toml
@@ -16,7 +16,7 @@ brotli-decompressor.workspace = true
 tracing.workspace = true
 
 [dependencies.jxl-bitstream]
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-bitstream"
 
 [dependencies.jxl-frame]
@@ -24,7 +24,7 @@ version = "0.13.0"
 path = "../jxl-frame"
 
 [dependencies.jxl-grid]
-version = "0.5.3"
+version = "1.0.0-alpha.0"
 path = "../jxl-grid"
 
 [dependencies.jxl-image]
@@ -32,17 +32,17 @@ version = "0.13.0"
 path = "../jxl-image"
 
 [dependencies.jxl-modular]
-version = "0.10.0"
+version = "0.11.0"
 path = "../jxl-modular"
 
 [dependencies.jxl-oxide-common]
-version = "0.2.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-oxide-common"
 
 [dependencies.jxl-threadpool]
-version = "0.1.1"
+version = "1.0.0-alpha.0"
 path = "../jxl-threadpool"
 
 [dependencies.jxl-vardct]
-version = "0.10.0"
+version = "0.11.0"
 path = "../jxl-vardct"

--- a/crates/jxl-jbr/Cargo.toml
+++ b/crates/jxl-jbr/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 brotli-decompressor.workspace = true

--- a/crates/jxl-jbr/src/reconstruct.rs
+++ b/crates/jxl-jbr/src/reconstruct.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use jxl_bitstream::Bitstream;
 use jxl_frame::data::{
-    decode_pass_group, HfGlobal, LfGroup, PassGroupParams, PassGroupParamsVardct,
+    HfGlobal, LfGroup, PassGroupParams, PassGroupParamsVardct, decode_pass_group,
 };
 use jxl_frame::header::Encoding;
 use jxl_frame::{Frame, FrameHeader};

--- a/crates/jxl-modular/Cargo.toml
+++ b/crates/jxl-modular/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
 version = "0.10.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 tracing.workspace = true

--- a/crates/jxl-modular/Cargo.toml
+++ b/crates/jxl-modular/Cargo.toml
@@ -8,28 +8,28 @@ keywords = ["jpeg-xl", "decoder", "jxl-oxide"]
 categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 
 [dependencies]
 tracing.workspace = true
 
 [dependencies.jxl-bitstream]
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-bitstream"
 
 [dependencies.jxl-coding]
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-coding"
 
 [dependencies.jxl-grid]
-version = "0.5.3"
+version = "1.0.0-alpha.0"
 path = "../jxl-grid"
 
 [dependencies.jxl-oxide-common]
-version = "0.2.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-oxide-common"
 
 [dependencies.jxl-threadpool]
-version = "0.1.1"
+version = "1.0.0-alpha.0"
 path = "../jxl-threadpool"

--- a/crates/jxl-modular/src/image.rs
+++ b/crates/jxl-modular/src/image.rs
@@ -258,7 +258,7 @@ impl<S: Sample> ModularImageDestination<S> {
                 let shift = hshift.min(vshift); // shift < 3
                 let pass_idx = *pass_shifts
                     .iter()
-                    .find(|(_, &(minshift, maxshift))| (minshift..maxshift).contains(&shift))
+                    .find(|&(_, &(minshift, maxshift))| (minshift..maxshift).contains(&shift))
                     .unwrap()
                     .0;
                 let pass_idx = pass_idx as usize;

--- a/crates/jxl-modular/src/image.rs
+++ b/crates/jxl-modular/src/image.rs
@@ -5,10 +5,10 @@ use jxl_coding::{Decoder, DecoderRleMode, RleToken};
 use jxl_grid::{AlignedGrid, AllocTracker, MutableSubgrid};
 
 use crate::{
+    MaConfig, ModularChannelInfo, ModularChannels, ModularHeader, Result,
     ma::{FlatMaTree, MaTreeLeafClustered, SimpleMaTable},
     predictor::{Predictor, PredictorState, Properties, WpHeader},
     sample::Sample,
-    MaConfig, ModularChannelInfo, ModularChannels, ModularHeader, Result,
 };
 
 #[derive(Debug)]

--- a/crates/jxl-modular/src/lib.rs
+++ b/crates/jxl-modular/src/lib.rs
@@ -4,7 +4,7 @@
 //! images are used mainly for lossless images, but lossy VarDCT images also use them to store
 //! various information, such as quantized LF images and varblock configurations.
 use jxl_bitstream::Bitstream;
-use jxl_oxide_common::{define_bundle, Bundle};
+use jxl_oxide_common::{Bundle, define_bundle};
 
 mod error;
 pub mod image;

--- a/crates/jxl-modular/src/ma.rs
+++ b/crates/jxl-modular/src/ma.rs
@@ -1,13 +1,13 @@
 use std::collections::VecDeque;
 use std::sync::Arc;
 
-use jxl_bitstream::{unpack_signed, Bitstream};
+use jxl_bitstream::{Bitstream, unpack_signed};
 use jxl_coding::Decoder;
 use jxl_grid::{AllocHandle, AllocTracker};
 use jxl_oxide_common::Bundle;
 
 use super::predictor::{Predictor, Properties};
-use crate::{sample::Sealed, Result, Sample};
+use crate::{Result, Sample, sample::Sealed};
 
 /// Meta-adaptive tree configuration.
 ///

--- a/crates/jxl-modular/src/param.rs
+++ b/crates/jxl-modular/src/param.rs
@@ -149,21 +149,13 @@ impl ChannelShift {
             } => {
                 let width = if has_h_subsample {
                     let size = width.div_ceil(2);
-                    if h_subsample {
-                        size
-                    } else {
-                        size * 2
-                    }
+                    if h_subsample { size } else { size * 2 }
                 } else {
                     width
                 };
                 let height = if has_v_subsample {
                     let size = height.div_ceil(2);
-                    if v_subsample {
-                        size
-                    } else {
-                        size * 2
-                    }
+                    if v_subsample { size } else { size * 2 }
                 } else {
                     height
                 };

--- a/crates/jxl-modular/src/predictor.rs
+++ b/crates/jxl-modular/src/predictor.rs
@@ -65,7 +65,7 @@ impl TryFrom<u32> for Predictor {
                 return Err(jxl_bitstream::Error::InvalidEnum {
                     name: "MaProperty",
                     value,
-                })
+                });
             }
         })
     }

--- a/crates/jxl-modular/src/transform.rs
+++ b/crates/jxl-modular/src/transform.rs
@@ -2,14 +2,14 @@
 
 use jxl_bitstream::{Bitstream, U};
 use jxl_grid::{AlignedGrid, AllocTracker, MutableSubgrid};
-use jxl_oxide_common::{define_bundle, Bundle};
+use jxl_oxide_common::{Bundle, define_bundle};
 use jxl_threadpool::JxlThreadPool;
 
 use super::{
-    predictor::{Predictor, WpHeader},
     ModularChannelInfo,
+    predictor::{Predictor, WpHeader},
 };
-use crate::{image::TransformedGrid, Error, Result, Sample};
+use crate::{Error, Result, Sample, image::TransformedGrid};
 
 mod palette;
 mod rct;

--- a/crates/jxl-modular/src/transform.rs
+++ b/crates/jxl-modular/src/transform.rs
@@ -1,3 +1,5 @@
+#![allow(unsafe_op_in_unsafe_fn)]
+
 use jxl_bitstream::{Bitstream, U};
 use jxl_grid::{AlignedGrid, AllocTracker, MutableSubgrid};
 use jxl_oxide_common::{define_bundle, Bundle};

--- a/crates/jxl-modular/src/transform/palette.rs
+++ b/crates/jxl-modular/src/transform/palette.rs
@@ -1,8 +1,8 @@
 use jxl_grid::{MutableSubgrid, SharedSubgrid};
 
 use crate::{
-    predictor::{Predictor, PredictorState},
     Sample,
+    predictor::{Predictor, PredictorState},
 };
 
 use super::Palette;

--- a/crates/jxl-modular/src/transform/rct.rs
+++ b/crates/jxl-modular/src/transform/rct.rs
@@ -128,7 +128,9 @@ unsafe fn run_rows_unsafe<S: Sample>(
         let height = grids[0].height();
         for y in 0..height {
             let mut rows = grids.each_mut().map(|g| g.get_row_mut(y));
-            f(&mut rows);
+            unsafe {
+                f(&mut rows);
+            }
             inverse_permute(permutation, rows);
         }
     });

--- a/crates/jxl-modular/src/transform/squeeze.rs
+++ b/crates/jxl-modular/src/transform/squeeze.rs
@@ -490,7 +490,7 @@ unsafe fn inverse_h_i16_aarch64_neon(merged: &mut MutableSubgrid<'_, i16>) {
 
     // SAFETY: int16x4_t doesn't need to be dropped.
     let mut scratch = vec![MaybeUninit::<int16x4_t>::uninit(); width];
-    let avg_width = (width + 1) / 2;
+    let avg_width = width.div_ceil(2);
 
     let h4 = height / 4;
     for y4 in 0..h4 {
@@ -999,7 +999,7 @@ unsafe fn inverse_v_i16_aarch64_neon(merged: &mut MutableSubgrid<'_, i16>) {
 
     // SAFETY: int16x4_t doesn't need to be dropped.
     let mut scratch = vec![MaybeUninit::<int16x4_t>::uninit(); height];
-    let avg_height = (height + 1) / 2;
+    let avg_height = height.div_ceil(2);
 
     let w4 = width / 4;
     for x4 in 0..w4 {
@@ -1057,7 +1057,7 @@ unsafe fn inverse_v_i16_wasm32_simd128(merged: &mut MutableSubgrid<'_, i16>) {
 
     // SAFETY: v128 doesn't need to be dropped.
     let mut scratch = vec![MaybeUninit::<v128>::uninit(); height];
-    let avg_height = (height + 1) / 2;
+    let avg_height = height.div_ceil(2);
 
     let w8 = width / 8;
     for x8 in 0..w8 {

--- a/crates/jxl-oxide-cli/Cargo.toml
+++ b/crates/jxl-oxide-cli/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
 version = "0.12.0"
-edition = "2021"
+edition = "2024"
 
 default-run = "jxl-oxide"
 

--- a/crates/jxl-oxide-cli/src/commands/slow_motion.rs
+++ b/crates/jxl-oxide-cli/src/commands/slow_motion.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::{value_parser, Parser};
+use clap::{Parser, value_parser};
 
 #[derive(Debug, Parser)]
 #[non_exhaustive]

--- a/crates/jxl-oxide-cli/src/commands/tests.rs
+++ b/crates/jxl-oxide-cli/src/commands/tests.rs
@@ -98,8 +98,8 @@ mod clap {
 mod color_encoding {
     use super::super::*;
     use jxl_oxide::{
-        color::{ColourSpace, TransferFunction},
         EnumColourEncoding, RenderingIntent,
+        color::{ColourSpace, TransferFunction},
     };
 
     fn test_encoding_eq(a: &EnumColourEncoding, b: &EnumColourEncoding) -> bool {

--- a/crates/jxl-oxide-cli/src/decode.rs
+++ b/crates/jxl-oxide-cli/src/decode.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use jxl_oxide::{AllocTracker, CropInfo, EnumColourEncoding, JxlImage, Render};
 
 use crate::commands::decode::*;
-use crate::{output, Error, Result};
+use crate::{Error, Result, output};
 
 pub fn handle_decode(args: DecodeArgs) -> Result<()> {
     let _guard = tracing::trace_span!("Handle decode subcommand").entered();
@@ -264,7 +264,9 @@ pub fn handle_decode(args: DecodeArgs) -> Result<()> {
             }
             OutputFormat::Npy => {
                 if args.icc_output.is_none() {
-                    tracing::warn!("--icc-output is not set. Numpy buffer alone cannot be used to display image as its colorspace is unknown.");
+                    tracing::warn!(
+                        "--icc-output is not set. Numpy buffer alone cannot be used to display image as its colorspace is unknown."
+                    );
                 }
 
                 output::write_npy(output, &keyframes, width, height).map_err(Error::WriteImage)?;

--- a/crates/jxl-oxide-cli/src/info.rs
+++ b/crates/jxl-oxide-cli/src/info.rs
@@ -5,7 +5,7 @@ use jxl_oxide::{
     AuxBoxData, ColorEncodingWithProfile, ExtraChannelType, JpegReconstructionStatus, JxlImage,
 };
 
-use crate::{commands::info::*, Error, Result};
+use crate::{Error, Result, commands::info::*};
 
 pub fn handle_info(args: InfoArgs) -> Result<()> {
     let _guard = tracing::trace_span!("Handle info subcommand").entered();

--- a/crates/jxl-oxide-cli/src/output/video.rs
+++ b/crates/jxl-oxide-cli/src/output/video.rs
@@ -118,11 +118,13 @@ unsafe extern "C" fn jxl_oxide_ffmpeg_log(
     vl: va_list::VaList<'static>,
 ) {
     let mut out = vec![0u8; 65536];
-    let vsnprintf = std::mem::transmute::<
-        unsafe extern "C" fn(*mut c_char, std::ffi::c_ulong, *const c_char, _) -> i32,
-        unsafe extern "C" fn(_, _, _, va_list::VaList<'static>) -> i32,
-    >(ffmpeg::vsnprintf);
-    vsnprintf(out.as_mut_ptr() as *mut c_char, 65536, fmt, vl);
+    unsafe {
+        let vsnprintf = std::mem::transmute::<
+            unsafe extern "C" fn(*mut c_char, std::ffi::c_ulong, *const c_char, _) -> i32,
+            unsafe extern "C" fn(_, _, _, va_list::VaList<'static>) -> i32,
+        >(ffmpeg::vsnprintf);
+        vsnprintf(out.as_mut_ptr() as *mut c_char, 65536, fmt, vl);
+    }
 
     let len = out.iter().position(|&v| v == 0).unwrap();
     let line = String::from_utf8_lossy(&out[..len]);

--- a/crates/jxl-oxide-cli/src/output/video.rs
+++ b/crates/jxl-oxide-cli/src/output/video.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_char, c_int, c_void, CStr};
+use std::ffi::{CStr, c_char, c_int, c_void};
 use std::fs::File;
 use std::path::Path;
 

--- a/crates/jxl-oxide-cli/src/output/video/context.rs
+++ b/crates/jxl-oxide-cli/src/output/video/context.rs
@@ -3,6 +3,7 @@ use std::{
     io::prelude::*,
 };
 
+use jxl_color::{AsIlluminant as _, AsPrimaries as _};
 use jxl_oxide::{HdrType, PixelFormat, Render};
 use rusty_ffmpeg::ffi as ffmpeg;
 
@@ -321,8 +322,8 @@ impl<W> VideoContext<W> {
                     let mut libsvtav1_opts =
                         format!("enable-hdr=1:content-light={max_cll},{max_fall}");
                     if let Some((lmin, lmax)) = mastering_luminances {
-                        let bt2100_chrm = jxl_oxide::color::Primaries::Bt2100.as_chromaticity();
-                        let d65_wtpt = jxl_oxide::color::WhitePoint::D65.as_chromaticity();
+                        let bt2100_chrm = jxl_oxide::color::Primaries::Bt2100.as_primaries();
+                        let d65_wtpt = jxl_oxide::color::WhitePoint::D65.as_illuminant();
 
                         write!(
                             &mut libsvtav1_opts,
@@ -351,10 +352,10 @@ impl<W> VideoContext<W> {
                         format!("hdr-opt=1:repeat-headers=1:max-cll={max_cll},{max_fall}");
                     if let Some((lmin, lmax)) = mastering_luminances {
                         let bt2100_chrm = jxl_oxide::color::Primaries::Bt2100
-                            .as_chromaticity()
+                            .as_primaries()
                             .map(|xy| xy.map(|v| (v * 50000.0 + 0.5) as i32));
                         let d65_wtpt = jxl_oxide::color::WhitePoint::D65
-                            .as_chromaticity()
+                            .as_illuminant()
                             .map(|v| (v * 50000.0 + 0.5) as i32);
                         let min_luminance = (lmin * 10000.0 + 0.5) as i32;
                         let max_luminance = (lmax * 10000.0 + 0.5) as i32;

--- a/crates/jxl-oxide-cli/src/output/video/context.rs
+++ b/crates/jxl-oxide-cli/src/output/video/context.rs
@@ -1,5 +1,5 @@
 use std::{
-    ffi::{c_int, c_void, CStr, CString},
+    ffi::{CStr, CString, c_int, c_void},
     io::prelude::*,
 };
 
@@ -205,7 +205,7 @@ impl<W> VideoContext<W> {
             PixelFormat::Gray | PixelFormat::Graya => ffmpeg::AV_PIX_FMT_GRAY16,
             PixelFormat::Rgb | PixelFormat::Rgba => ffmpeg::AV_PIX_FMT_RGB48,
             PixelFormat::Cmyk | PixelFormat::Cmyka => {
-                return Err(Error::from_ffmpeg_msg("CMYK not supported"))
+                return Err(Error::from_ffmpeg_msg("CMYK not supported"));
             }
         };
 
@@ -476,7 +476,8 @@ impl<W> VideoContext<W> {
             ffmpeg::avcodec_send_frame(self.video_ctx, frame_ptr).into_ffmpeg_result()?;
 
             loop {
-                let ret = ffmpeg::avcodec_receive_packet(self.video_ctx, self.packet_ptr).into_ffmpeg_result();
+                let ret = ffmpeg::avcodec_receive_packet(self.video_ctx, self.packet_ptr)
+                    .into_ffmpeg_result();
                 match ret {
                     Err(Error::Ffmpeg {
                         averror: Some(e), ..

--- a/crates/jxl-oxide-cli/src/output/video/filter.rs
+++ b/crates/jxl-oxide-cli/src/output/video/filter.rs
@@ -26,17 +26,19 @@ impl VideoFilter {
         filter: &CStr,
         name: Option<&CStr>,
     ) -> Result<*mut ffmpeg::AVFilterContext> {
-        let filter = ffmpeg::avfilter_get_by_name(filter.as_ptr());
+        let filter = unsafe { ffmpeg::avfilter_get_by_name(filter.as_ptr()) };
         if filter.is_null() {
             tracing::error!(name = ?filter, "filter not found");
             return Err(Error::from_ffmpeg_msg("filter not found"));
         }
 
-        let filter_ctx = ffmpeg::avfilter_graph_alloc_filter(
-            self.graph_ptr,
-            filter,
-            name.map(|v| v.as_ptr()).unwrap_or(std::ptr::null()),
-        );
+        let filter_ctx = unsafe {
+            ffmpeg::avfilter_graph_alloc_filter(
+                self.graph_ptr,
+                filter,
+                name.map(|v| v.as_ptr()).unwrap_or(std::ptr::null()),
+            )
+        };
         if filter_ctx.is_null() {
             tracing::error!(filter_name = ?filter, ?name, "cannot allocate filter");
             return Err(Error::from_ffmpeg_msg("cannot allocate filter"));

--- a/crates/jxl-oxide-cli/src/output/video/filter.rs
+++ b/crates/jxl-oxide-cli/src/output/video/filter.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_int, CStr};
+use std::ffi::{CStr, c_int};
 
 use jxl_oxide::HdrType;
 use rusty_ffmpeg::ffi as ffmpeg;

--- a/crates/jxl-oxide-common/Cargo.toml
+++ b/crates/jxl-oxide-common/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 

--- a/crates/jxl-oxide-common/Cargo.toml
+++ b/crates/jxl-oxide-common/Cargo.toml
@@ -6,11 +6,11 @@ repository = "https://github.com/tirr-c/jxl-oxide.git"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 
-version = "0.2.0"
+version = "1.0.0-alpha.0"
 edition = "2024"
 
 [dependencies]
 
 [dependencies.jxl-bitstream]
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-bitstream"

--- a/crates/jxl-oxide-fuzz/Cargo.toml
+++ b/crates/jxl-oxide-fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "jxl-oxide-fuzz"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition = "2024"
 
 [dependencies.jxl-oxide]
 path = "../jxl-oxide"

--- a/crates/jxl-oxide-tests/Cargo.toml
+++ b/crates/jxl-oxide-tests/Cargo.toml
@@ -32,9 +32,9 @@ version = "0.1.39"
 optional = true
 
 [dependencies.rand]
-version = "0.8.5"
+version = "0.9.0"
 default-features = false
-features = ["getrandom", "small_rng"]
+features = ["os_rng", "small_rng"]
 optional = true
 
 [dependencies.reqwest]

--- a/crates/jxl-oxide-tests/Cargo.toml
+++ b/crates/jxl-oxide-tests/Cargo.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 ring = "0.17.8"

--- a/crates/jxl-oxide-tests/benches/decode.rs
+++ b/crates/jxl-oxide-tests/benches/decode.rs
@@ -1,6 +1,6 @@
 use std::{io::Cursor, path::Path, time::Duration};
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use jxl_oxide::{EnumColourEncoding, JxlThreadPool, RenderingIntent};
 
 #[cfg(feature = "mimalloc")]

--- a/crates/jxl-oxide-tests/tests/conformance/mod.rs
+++ b/crates/jxl-oxide-tests/tests/conformance/mod.rs
@@ -74,7 +74,9 @@ fn run_test(
 
                     let abs_error = (output - reference).abs();
                     if debug && abs_error >= expected_peak_error {
-                        eprintln!("abs_error is larger than max peak_error, at (x={x}, y={y}, c={c}), reference={reference}, actual={output}");
+                        eprintln!(
+                            "abs_error is larger than max peak_error, at (x={x}, y={y}, c={c}), reference={reference}, actual={output}"
+                        );
                     }
                     *peak_error = peak_error.max(abs_error);
                     *sum_se += abs_error * abs_error;

--- a/crates/jxl-oxide-tests/tests/crop/mod.rs
+++ b/crates/jxl-oxide-tests/tests/crop/mod.rs
@@ -74,7 +74,9 @@ fn test_crop_region(image: &JxlImage, tester_image: &JxlImage, crop: CropInfo, n
                 let expected_row = &expected_row[crop_left as usize..][..crop_width as usize];
                 for (x, (expected, actual)) in expected_row.iter().zip(actual_row).enumerate() {
                     if (expected - actual).abs() > 1e-6 {
-                        eprintln!("Test failed at c={c}, x={x}, y={y} (expected={expected}, actual={actual})");
+                        eprintln!(
+                            "Test failed at c={c}, x={x}, y={y} (expected={expected}, actual={actual})"
+                        );
 
                         let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
                         path.push("tests/.artifact");
@@ -93,7 +95,9 @@ fn test_crop_region(image: &JxlImage, tester_image: &JxlImage, crop: CropInfo, n
                             cropped.to_string_lossy()
                         );
 
-                        panic!("Test failed at c={c}, x={x}, y={y} (expected={expected}, actual={actual})");
+                        panic!(
+                            "Test failed at c={c}, x={x}, y={y} (expected={expected}, actual={actual})"
+                        );
                     }
                 }
             }
@@ -200,7 +204,9 @@ fn write_npy(render: &Render, path: impl AsRef<std::path::Path>) {
     let num_channels = image.channels();
     let width = image.width();
     let height = image.height();
-    let header_string = format!("{{'descr': '<f4', 'fortran_order': False, 'shape': (1, {height}, {width}, {num_channels}), }}\n");
+    let header_string = format!(
+        "{{'descr': '<f4', 'fortran_order': False, 'shape': (1, {height}, {width}, {num_channels}), }}\n"
+    );
     eprintln!("width={width}, height={height}, num_channels={num_channels}");
     let header_len = header_string.len() as u16;
     file.write_all(&header_len.to_le_bytes()).unwrap();

--- a/crates/jxl-oxide-tests/tests/crop/mod.rs
+++ b/crates/jxl-oxide-tests/tests/crop/mod.rs
@@ -5,7 +5,7 @@ use jxl_oxide_tests as util;
 use rand::prelude::*;
 
 fn run_test(buf: &[u8], name: &str) {
-    let mut rng = rand::rngs::SmallRng::from_entropy();
+    let mut rng = rand::rngs::SmallRng::from_os_rng();
 
     let image = JxlImage::builder()
         .read(Cursor::new(buf))
@@ -13,8 +13,8 @@ fn run_test(buf: &[u8], name: &str) {
 
     let width = image.width();
     let height = image.height();
-    let width_dist = rand::distributions::Uniform::new_inclusive(128, (width / 2).max(128));
-    let height_dist = rand::distributions::Uniform::new_inclusive(128, (height / 2).max(128));
+    let width_dist = rand::distr::Uniform::new_inclusive(128, (width / 2).max(128)).unwrap();
+    let height_dist = rand::distr::Uniform::new_inclusive(128, (height / 2).max(128)).unwrap();
 
     let mut tester_image = JxlImage::builder()
         .read(Cursor::new(buf))
@@ -23,8 +23,8 @@ fn run_test(buf: &[u8], name: &str) {
     for _ in 0..4 {
         let crop_width = width_dist.sample(&mut rng);
         let crop_height = height_dist.sample(&mut rng);
-        let crop_left = rng.gen_range(0..=(width - crop_width));
-        let crop_top = rng.gen_range(0..=(height - crop_height));
+        let crop_left = rng.random_range(0..=(width - crop_width));
+        let crop_top = rng.random_range(0..=(height - crop_height));
         let crop = CropInfo {
             left: crop_left,
             top: crop_top,

--- a/crates/jxl-oxide-wasm/Cargo.toml
+++ b/crates/jxl-oxide-wasm/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-miniz_oxide = "0.7.2"
+miniz_oxide = "0.8.7"
 png = "0.17.13"
 wasm-bindgen = "0.2.93"
 

--- a/crates/jxl-oxide-wasm/Cargo.toml
+++ b/crates/jxl-oxide-wasm/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 version = "0.12.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/crates/jxl-oxide-wasm/src/lib.rs
+++ b/crates/jxl-oxide-wasm/src/lib.rs
@@ -1,6 +1,6 @@
 use jxl_oxide::{
-    color::ColourEncoding, EnumColourEncoding, InitializeResult, JxlImage, PixelFormat, Render,
-    RenderingIntent, UninitializedJxlImage,
+    EnumColourEncoding, InitializeResult, JxlImage, PixelFormat, Render, RenderingIntent,
+    UninitializedJxlImage, color::ColourEncoding,
 };
 use wasm_bindgen::prelude::*;
 
@@ -285,7 +285,7 @@ impl RenderResult {
             PixelFormat::Rgb => png::ColorType::Rgb,
             PixelFormat::Rgba => png::ColorType::Rgba,
             PixelFormat::Cmyk | PixelFormat::Cmyka => {
-                return Err(String::from("unsupported colorspace"))
+                return Err(String::from("unsupported colorspace"));
             }
         };
         let depth = if self.need_high_precision {

--- a/crates/jxl-oxide/Cargo.toml
+++ b/crates/jxl-oxide/Cargo.toml
@@ -65,7 +65,7 @@ version = "6.0.0"
 optional = true
 
 [dependencies.moxcms]
-version = "0.5.1"
+version = "0.6.0"
 optional = true
 
 [features]

--- a/crates/jxl-oxide/Cargo.toml
+++ b/crates/jxl-oxide/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
 version = "0.12.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 brotli-decompressor.workspace = true

--- a/crates/jxl-oxide/Cargo.toml
+++ b/crates/jxl-oxide/Cargo.toml
@@ -25,7 +25,7 @@ default-features = false
 optional = true
 
 [dependencies.jxl-bitstream]
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-bitstream"
 
 [dependencies.jxl-color]
@@ -37,7 +37,7 @@ version = "0.13.0"
 path = "../jxl-frame"
 
 [dependencies.jxl-grid]
-version = "0.5.3"
+version = "1.0.0-alpha.0"
 path = "../jxl-grid"
 
 [dependencies.jxl-image]
@@ -49,7 +49,7 @@ version = "0.2.0"
 path = "../jxl-jbr"
 
 [dependencies.jxl-oxide-common]
-version = "0.2.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-oxide-common"
 
 [dependencies.jxl-render]
@@ -57,7 +57,7 @@ version = "0.12.0"
 path = "../jxl-render"
 
 [dependencies.jxl-threadpool]
-version = "0.1.2"
+version = "1.0.0-alpha.0"
 path = "../jxl-threadpool"
 
 [dependencies.lcms2]

--- a/crates/jxl-oxide/src/aux_box.rs
+++ b/crates/jxl-oxide/src/aux_box.rs
@@ -1,8 +1,8 @@
 use std::io::Write;
 
 use brotli_decompressor::DecompressorWriter;
-use jxl_bitstream::container::box_header::ContainerBoxType;
 use jxl_bitstream::ParseEvent;
+use jxl_bitstream::container::box_header::ContainerBoxType;
 
 use crate::Result;
 

--- a/crates/jxl-oxide/src/lib.rs
+++ b/crates/jxl-oxide/src/lib.rs
@@ -158,16 +158,12 @@ use jxl_render::ImageWithRegion;
 use jxl_render::Region;
 use jxl_render::{IndexedFrame, RenderContext};
 
-pub use jxl_color::header as color;
-pub use jxl_color::{
-    ColorEncodingWithProfile, ColorManagementSystem, EnumColourEncoding, NullCms,
-    PreparedTransform, RenderingIntent,
-};
+pub use jxl_color::{ColorEncodingWithProfile, ColorManagementSystem, NullCms, PreparedTransform};
 pub use jxl_frame::header as frame;
 pub use jxl_frame::{Frame, FrameHeader};
 pub use jxl_grid::{AlignedGrid, AllocTracker};
-pub use jxl_image as image;
-pub use jxl_image::{ExtraChannelType, ImageHeader};
+pub use jxl_image::color::{self, EnumColourEncoding, RenderingIntent};
+pub use jxl_image::{self as image, ExtraChannelType, ImageHeader};
 pub use jxl_jbr as jpeg_bitstream;
 pub use jxl_threadpool::JxlThreadPool;
 
@@ -541,10 +537,10 @@ impl JxlImage {
     pub fn rendered_icc(&self) -> Vec<u8> {
         let encoding = self.ctx.requested_color_encoding();
         match encoding.encoding() {
-            jxl_color::ColourEncoding::Enum(encoding) => {
+            color::ColourEncoding::Enum(encoding) => {
                 jxl_color::icc::colour_encoding_to_icc(encoding)
             }
-            jxl_color::ColourEncoding::IccProfile(_) => encoding.icc_profile().to_vec(),
+            color::ColourEncoding::IccProfile(_) => encoding.icc_profile().to_vec(),
         }
     }
 
@@ -582,8 +578,8 @@ impl JxlImage {
     /// Returns `None` if the image is not HDR one.
     pub fn hdr_type(&self) -> Option<HdrType> {
         self.ctx.suggested_hdr_tf().and_then(|tf| match tf {
-            jxl_color::TransferFunction::Pq => Some(HdrType::Pq),
-            jxl_color::TransferFunction::Hlg => Some(HdrType::Hlg),
+            color::TransferFunction::Pq => Some(HdrType::Pq),
+            color::TransferFunction::Hlg => Some(HdrType::Hlg),
             _ => None,
         })
     }

--- a/crates/jxl-render/Cargo.toml
+++ b/crates/jxl-render/Cargo.toml
@@ -16,11 +16,11 @@ bytemuck.workspace = true
 tracing.workspace = true
 
 [dependencies.jxl-bitstream]
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-bitstream"
 
 [dependencies.jxl-coding]
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-coding"
 
 [dependencies.jxl-color]
@@ -32,7 +32,7 @@ version = "0.13.0"
 path = "../jxl-frame"
 
 [dependencies.jxl-grid]
-version = "0.5.3"
+version = "1.0.0-alpha.0"
 path = "../jxl-grid"
 
 [dependencies.jxl-image]
@@ -40,17 +40,17 @@ version = "0.13.0"
 path = "../jxl-image"
 
 [dependencies.jxl-modular]
-version = "0.10.0"
+version = "0.11.0"
 path = "../jxl-modular"
 
 [dependencies.jxl-oxide-common]
-version = "0.2.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-oxide-common"
 
 [dependencies.jxl-threadpool]
-version = "0.1.1"
+version = "1.0.0-alpha.0"
 path = "../jxl-threadpool"
 
 [dependencies.jxl-vardct]
-version = "0.10.1"
+version = "0.11.0"
 path = "../jxl-vardct"

--- a/crates/jxl-render/Cargo.toml
+++ b/crates/jxl-render/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
 version = "0.12.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 bytemuck.workspace = true

--- a/crates/jxl-render/src/blend.rs
+++ b/crates/jxl-render/src/blend.rs
@@ -1,16 +1,16 @@
 use std::sync::Arc;
 
 use jxl_frame::{
+    Frame,
     data::{BlendingModeInformation, PatchRef},
     header::{BlendMode as FrameBlendMode, BlendingInfo},
-    Frame,
 };
 use jxl_grid::{AlignedGrid, MutableSubgrid, SharedSubgrid};
 use jxl_image::ImageHeader;
 use jxl_modular::Sample;
 use jxl_threadpool::JxlThreadPool;
 
-use crate::{image::ImageBuffer, ImageWithRegion, Reference, Region, Result};
+use crate::{ImageWithRegion, Reference, Region, Result, image::ImageBuffer};
 
 #[derive(Debug)]
 enum BlendMode<'a> {

--- a/crates/jxl-render/src/features/noise.rs
+++ b/crates/jxl-render/src/features/noise.rs
@@ -1,6 +1,6 @@
 use std::num::Wrapping;
 
-use jxl_frame::{data::NoiseParameters, FrameHeader};
+use jxl_frame::{FrameHeader, data::NoiseParameters};
 use jxl_grid::{AlignedGrid, AllocTracker, SharedSubgrid};
 use jxl_threadpool::JxlThreadPool;
 

--- a/crates/jxl-render/src/features/spline.rs
+++ b/crates/jxl-render/src/features/spline.rs
@@ -1,8 +1,8 @@
 use std::ops::{Add, Mul, Sub};
 
 use jxl_frame::{
-    data::{QuantSpline, Splines},
     FrameHeader,
+    data::{QuantSpline, Splines},
 };
 
 use crate::ImageWithRegion;
@@ -325,9 +325,5 @@ fn erf(x: f32) -> f32 {
     let result = -inv_denom5 * inv_denom5 + 1.0;
 
     // Change sign if needed.
-    if x < 0.0 {
-        -result
-    } else {
-        result
-    }
+    if x < 0.0 { -result } else { result }
 }

--- a/crates/jxl-render/src/filter/epf.rs
+++ b/crates/jxl-render/src/filter/epf.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
-use jxl_frame::{data::LfGroup, filter::EpfParams, FrameHeader};
+use jxl_frame::{FrameHeader, data::LfGroup, filter::EpfParams};
 use jxl_grid::{AlignedGrid, MutableSubgrid, SharedSubgrid};
 use jxl_modular::Sample;
 use jxl_threadpool::JxlThreadPool;
 
-use crate::{util, ImageWithRegion, Region};
+use crate::{ImageWithRegion, Region, util};
 
 pub fn apply_epf<S: Sample>(
     fb_image: &mut ImageWithRegion,

--- a/crates/jxl-render/src/filter/epf.rs
+++ b/crates/jxl-render/src/filter/epf.rs
@@ -237,7 +237,9 @@ pub(super) unsafe fn run_epf_rows(
                             epf_params,
                             skip_inner,
                         };
-                        handle_row_simd(row);
+                        unsafe {
+                            handle_row_simd(row);
+                        }
                     }
                 }
 

--- a/crates/jxl-render/src/filter/gabor.rs
+++ b/crates/jxl-render/src/filter/gabor.rs
@@ -101,7 +101,9 @@ pub(super) unsafe fn run_gabor_rows_unsafe<'buf>(
                 output_row,
                 weights,
             };
-            handle_row(row);
+            unsafe {
+                handle_row(row);
+            }
         }
     });
 

--- a/crates/jxl-render/src/filter/impls.rs
+++ b/crates/jxl-render/src/filter/impls.rs
@@ -1,3 +1,5 @@
+#![allow(unsafe_op_in_unsafe_fn)]
+
 #[cfg(target_arch = "aarch64")]
 mod aarch64;
 pub(super) mod generic;

--- a/crates/jxl-render/src/filter/impls/aarch64.rs
+++ b/crates/jxl-render/src/filter/impls/aarch64.rs
@@ -1,12 +1,12 @@
 use std::arch::is_aarch64_feature_detected;
 
-use jxl_frame::{filter::EpfParams, FrameHeader};
+use jxl_frame::{FrameHeader, filter::EpfParams};
 use jxl_grid::{AlignedGrid, MutableSubgrid};
 use jxl_threadpool::JxlThreadPool;
 
+use crate::Region;
 use crate::filter::epf::run_epf_rows;
 use crate::filter::gabor::{run_gabor_row_generic, run_gabor_rows, run_gabor_rows_unsafe};
-use crate::Region;
 
 mod epf;
 mod gabor;

--- a/crates/jxl-render/src/filter/impls/generic.rs
+++ b/crates/jxl-render/src/filter/impls/generic.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code)]
 
-use jxl_frame::{filter::EpfParams, FrameHeader};
+use jxl_frame::{FrameHeader, filter::EpfParams};
 use jxl_grid::{AlignedGrid, MutableSubgrid};
 use jxl_threadpool::JxlThreadPool;
 
 use crate::{
-    filter::{epf::run_epf_rows, gabor::run_gabor_rows},
     Region,
+    filter::{epf::run_epf_rows, gabor::run_gabor_rows},
 };
 
 pub(crate) mod epf;

--- a/crates/jxl-render/src/filter/impls/wasm32.rs
+++ b/crates/jxl-render/src/filter/impls/wasm32.rs
@@ -1,9 +1,9 @@
-use jxl_frame::{filter::EpfParams, FrameHeader};
+use jxl_frame::{FrameHeader, filter::EpfParams};
 use jxl_grid::{AlignedGrid, MutableSubgrid};
 use jxl_threadpool::JxlThreadPool;
 
-use crate::filter::epf::run_epf_rows;
 use crate::Region;
+use crate::filter::epf::run_epf_rows;
 
 mod epf;
 

--- a/crates/jxl-render/src/filter/impls/x86_64.rs
+++ b/crates/jxl-render/src/filter/impls/x86_64.rs
@@ -1,13 +1,13 @@
-use jxl_frame::{filter::EpfParams, FrameHeader};
+use jxl_frame::{FrameHeader, filter::EpfParams};
 use jxl_grid::{AlignedGrid, MutableSubgrid};
 use jxl_threadpool::JxlThreadPool;
 
 use crate::{
+    Region,
     filter::{
         epf::run_epf_rows,
         gabor::{run_gabor_row_generic, run_gabor_rows, run_gabor_rows_unsafe},
     },
-    Region,
 };
 
 mod epf_sse41;

--- a/crates/jxl-render/src/image.rs
+++ b/crates/jxl-render/src/image.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
-use jxl_frame::{data::GlobalModular, FrameHeader};
+use jxl_frame::{FrameHeader, data::GlobalModular};
 use jxl_grid::{AlignedGrid, AllocTracker, MutableSubgrid};
 use jxl_image::{BitDepth, ImageHeader};
 use jxl_modular::{ChannelShift, Sample};
 use jxl_threadpool::JxlThreadPool;
 use jxl_vardct::LfChannelDequantization;
 
-use crate::{util, FrameRender, FrameRenderHandle, Region, Result};
+use crate::{FrameRender, FrameRenderHandle, Region, Result, util};
 
 #[derive(Debug)]
 pub enum ImageBuffer {

--- a/crates/jxl-render/src/lib.rs
+++ b/crates/jxl-render/src/lib.rs
@@ -6,7 +6,7 @@ use jxl_color::{
     ColorEncodingWithProfile, ColorManagementSystem, ColorTransform, ColourEncoding, ColourSpace,
     EnumColourEncoding,
 };
-use jxl_frame::{header::FrameType, Frame, FrameContext};
+use jxl_frame::{Frame, FrameContext, header::FrameType};
 use jxl_grid::AllocTracker;
 use jxl_image::{ImageHeader, ImageMetadata};
 use jxl_modular::Sample;

--- a/crates/jxl-render/src/modular.rs
+++ b/crates/jxl-render/src/modular.rs
@@ -1,7 +1,7 @@
-use jxl_frame::{data::GlobalModular, FrameHeader};
-use jxl_modular::{image::TransformedModularSubimage, Sample};
+use jxl_frame::{FrameHeader, data::GlobalModular};
+use jxl_modular::{Sample, image::TransformedModularSubimage};
 
-use crate::{util, Error, ImageWithRegion, IndexedFrame, Region, RenderCache, Result};
+use crate::{Error, ImageWithRegion, IndexedFrame, Region, RenderCache, Result, util};
 
 pub(crate) fn render_modular<S: Sample>(
     frame: &IndexedFrame,

--- a/crates/jxl-render/src/render.rs
+++ b/crates/jxl-render/src/render.rs
@@ -7,8 +7,8 @@ use jxl_modular::Sample;
 use jxl_threadpool::JxlThreadPool;
 
 use crate::{
-    blend, features, filter, modular, state::RenderCache, util, vardct, Error, ImageWithRegion,
-    IndexedFrame, Reference, ReferenceFrames, Region, Result,
+    Error, ImageWithRegion, IndexedFrame, Reference, ReferenceFrames, Region, Result, blend,
+    features, filter, modular, state::RenderCache, util, vardct,
 };
 
 pub(crate) fn render_frame<S: Sample>(

--- a/crates/jxl-render/src/state.rs
+++ b/crates/jxl-render/src/state.rs
@@ -7,7 +7,7 @@ use jxl_frame::data::{HfGlobal, LfGlobal, LfGroup};
 use jxl_modular::{ChannelShift, Sample};
 
 use crate::{
-    image::RenderedImage, Error, ImageWithRegion, IndexedFrame, Reference, Region, Result,
+    Error, ImageWithRegion, IndexedFrame, Reference, Region, Result, image::RenderedImage,
 };
 
 pub type RenderOp<S> =
@@ -210,7 +210,7 @@ impl<S: Sample> FrameRenderHandle<S> {
                     return Ok(render_ref);
                 }
                 FrameRender::None | FrameRender::InProgress(_) => {
-                    return Err(Error::IncompleteFrame)
+                    return Err(Error::IncompleteFrame);
                 }
                 FrameRender::Err(e) => return Err(e),
                 FrameRender::ErrTaken => return Err(Error::FailedReference),

--- a/crates/jxl-render/src/util.rs
+++ b/crates/jxl-render/src/util.rs
@@ -2,18 +2,18 @@ use jxl_color::{
     ColorEncodingWithProfile, ColorTransform, ColourEncoding, ColourSpace, EnumColourEncoding,
 };
 use jxl_frame::{
+    Frame, FrameHeader,
     data::{LfGlobal, LfGroup},
     filter::{EdgePreservingFilter, EpfParams},
     header::FrameType,
-    Frame, FrameHeader,
 };
 use jxl_grid::{AlignedGrid, MutableSubgrid};
 use jxl_image::ImageHeader;
-use jxl_modular::{image::TransformedModularSubimage, ChannelShift, Sample};
+use jxl_modular::{ChannelShift, Sample, image::TransformedModularSubimage};
 use jxl_threadpool::JxlThreadPool;
 
 use crate::{
-    image::ImageBuffer, vardct::copy_lf_dequant, ImageWithRegion, IndexedFrame, Region, Result,
+    ImageWithRegion, IndexedFrame, Region, Result, image::ImageBuffer, vardct::copy_lf_dequant,
 };
 
 pub(crate) fn image_region_to_frame(

--- a/crates/jxl-render/src/vardct/generic/transform.rs
+++ b/crates/jxl-render/src/vardct/generic/transform.rs
@@ -5,7 +5,7 @@ use jxl_vardct::{BlockInfo, TransformType};
 
 use crate::vardct::{
     dct_common::DctDirection,
-    transform_common::{transform_varblocks_inner, AFV_BASIS},
+    transform_common::{AFV_BASIS, transform_varblocks_inner},
 };
 
 use super::dct_2d;

--- a/crates/jxl-render/src/vardct/mod.rs
+++ b/crates/jxl-render/src/vardct/mod.rs
@@ -3,8 +3,8 @@
 use std::collections::HashMap;
 
 use jxl_frame::{
-    data::{HfGlobal, LfGlobal, LfGroup, PassGroupParams, PassGroupParamsVardct},
     FrameHeader,
+    data::{HfGlobal, LfGlobal, LfGroup, PassGroupParams, PassGroupParamsVardct},
 };
 use jxl_grid::{AlignedGrid, MutableSubgrid, SharedSubgrid};
 use jxl_image::ImageHeader;
@@ -15,8 +15,8 @@ use jxl_vardct::{
 };
 
 use crate::{
-    image::ImageBuffer, modular, util, Error, ImageWithRegion, IndexedFrame, Reference, Region,
-    RenderCache, Result,
+    Error, ImageWithRegion, IndexedFrame, Reference, Region, RenderCache, Result,
+    image::ImageBuffer, modular, util,
 };
 
 mod dct_common;

--- a/crates/jxl-render/src/vardct/mod.rs
+++ b/crates/jxl-render/src/vardct/mod.rs
@@ -1,3 +1,5 @@
+#![allow(unsafe_op_in_unsafe_fn)]
+
 use std::collections::HashMap;
 
 use jxl_frame::{

--- a/crates/jxl-render/src/vardct/transform_common.rs
+++ b/crates/jxl-render/src/vardct/transform_common.rs
@@ -53,7 +53,9 @@ pub unsafe fn transform_varblocks_inner(
                             *out.get_mut(x, y) = *lf.get(shifted_bx + x, shifted_by + y);
                         }
                     }
-                    dct(&mut out, DctDirection::Forward);
+                    unsafe {
+                        dct(&mut out, DctDirection::Forward);
+                    }
                     for y in 0..bh {
                         for x in 0..bw {
                             *out.get_mut(x, y) /= scale_f(y, 5 - logbh) * scale_f(x, 5 - logbw);
@@ -64,7 +66,9 @@ pub unsafe fn transform_varblocks_inner(
                 let mut block = coeff
                     .borrow_mut()
                     .subgrid(left..(left + bw * 8), top..(top + bh * 8));
-                transform(&mut block, dct_select);
+                unsafe {
+                    transform(&mut block, dct_select);
+                }
             },
         );
     }

--- a/crates/jxl-render/src/vardct/transform_common.rs
+++ b/crates/jxl-render/src/vardct/transform_common.rs
@@ -3,8 +3,8 @@ use jxl_modular::ChannelShift;
 use jxl_vardct::{BlockInfo, TransformType};
 
 use crate::vardct::{
-    dct_common::{scale_f, DctDirection},
     VarblockInfo,
+    dct_common::{DctDirection, scale_f},
 };
 
 #[inline(always)]

--- a/crates/jxl-threadpool/Cargo.toml
+++ b/crates/jxl-threadpool/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 keywords = ["jxl-oxide"]
 license = "MIT OR Apache-2.0"
 
-version = "0.1.2"
+version = "1.0.0-alpha.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/jxl-threadpool/Cargo.toml
+++ b/crates/jxl-threadpool/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jxl-oxide"]
 license = "MIT OR Apache-2.0"
 
 version = "0.1.2"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 tracing.workspace = true

--- a/crates/jxl-vardct/Cargo.toml
+++ b/crates/jxl-vardct/Cargo.toml
@@ -8,32 +8,32 @@ keywords = ["jpeg-xl", "decoder", "jxl-oxide"]
 categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
-version = "0.10.1"
+version = "0.11.0"
 edition = "2024"
 
 [dependencies]
 tracing.workspace = true
 
 [dependencies.jxl-bitstream]
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-bitstream"
 
 [dependencies.jxl-coding]
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-coding"
 
 [dependencies.jxl-grid]
-version = "0.5.3"
+version = "1.0.0-alpha.0"
 path = "../jxl-grid"
 
 [dependencies.jxl-modular]
-version = "0.10.0"
+version = "0.11.0"
 path = "../jxl-modular"
 
 [dependencies.jxl-oxide-common]
-version = "0.2.0"
+version = "1.0.0-alpha.0"
 path = "../jxl-oxide-common"
 
 [dependencies.jxl-threadpool]
-version = "0.1.1"
+version = "1.0.0-alpha.0"
 path = "../jxl-threadpool"

--- a/crates/jxl-vardct/Cargo.toml
+++ b/crates/jxl-vardct/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
 version = "0.10.1"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 tracing.workspace = true

--- a/crates/jxl-vardct/src/dequant.rs
+++ b/crates/jxl-vardct/src/dequant.rs
@@ -179,11 +179,7 @@ impl DequantMatrixParams {
         }
 
         fn mult(x: f32) -> f32 {
-            if x > 0.0 {
-                1.0 + x
-            } else {
-                1.0 / (1.0 - x)
-            }
+            if x > 0.0 { 1.0 + x } else { 1.0 / (1.0 - x) }
         }
 
         fn dct_quant_weights(params: &[f32], width: u32, height: u32) -> Result<Vec<f32>> {

--- a/crates/jxl-vardct/src/lf.rs
+++ b/crates/jxl-vardct/src/lf.rs
@@ -1,7 +1,7 @@
 use jxl_bitstream::{Bitstream, U};
 use jxl_grid::AllocTracker;
 use jxl_modular::{ChannelShift, MaConfig, Modular, ModularParams, Sample};
-use jxl_oxide_common::{define_bundle, Bundle};
+use jxl_oxide_common::{Bundle, define_bundle};
 
 use crate::Result;
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -61,14 +61,14 @@ dependencies = [
 
 [[package]]
 name = "jxl-bitstream"
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "jxl-coding"
-version = "0.6.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "jxl-bitstream",
  "tracing",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "jxl-grid"
-version = "0.5.3"
+version = "1.0.0-alpha.0"
 dependencies = [
  "tracing",
 ]
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "jxl-modular"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "jxl-oxide-common"
-version = "0.2.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "jxl-bitstream",
 ]
@@ -206,14 +206,14 @@ dependencies = [
 
 [[package]]
 name = "jxl-threadpool"
-version = "0.1.2"
+version = "1.0.0-alpha.0"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "jxl-vardct"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -6,7 +6,7 @@ members = ["."]
 name = "jxl-oxide-libfuzzer"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition = "2024"
 
 [package.metadata]
 cargo-fuzz = true


### PR DESCRIPTION
jxl-oxide 0.12.0 will require Rust 1.85 or above.