### PR TITLE
Stabilize jxl-bitstream, jxl-oxide-common, jxl-coding, jxl-threadpool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,14 +1052,14 @@ dependencies = [
 
 [[package]]
 name = "jxl-bitstream"
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "jxl-coding"
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 dependencies = [
  "jxl-bitstream",
  "tracing",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "jxl-grid"
-version = "1.0.0-alpha.0"
+version = "0.6.0"
 dependencies = [
  "tracing",
 ]
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "jxl-oxide-common"
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 dependencies = [
  "jxl-bitstream",
 ]
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "jxl-threadpool"
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 dependencies = [
  "rayon",
  "rayon-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,9 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -244,9 +244,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.18"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "jobserver",
  "libc",
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.35"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.35"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -691,9 +691,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "half"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -1292,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
@@ -1308,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b20daca3a4ac14dbdc753c5e90fc7b490a48a9131daed3c9a9ced7b2defd37b"
+checksum = "ec9d6fac27761dabcd4ee73571cdb06b7022dc99089acbe5435691edffaac0f4"
 dependencies = [
  "cc",
  "libc",
@@ -1367,9 +1367,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mimalloc"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03cb1f88093fe50061ca1195d336ffec131347c7b833db31f9ab62a2d1b7925f"
+checksum = "995942f432bbb4822a7e9c3faa87a695185b0d09273ba85f097b54f4e458f2af"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -1388,9 +1388,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -1409,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5cbbb08b708abf222897b245cb1a1e4877d6c403cf2e7aa618efaf0390a0bc"
+checksum = "22b5f1d64e65ddd89792dffd073a1305b3ba5263e64f7885b91fb241cd8b9ae2"
 dependencies = [
  "chrono",
  "num-traits",
@@ -1613,9 +1613,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1623,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -1652,9 +1652,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
+checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
 dependencies = [
  "bytes",
  "getrandom 0.3.2",
@@ -1701,13 +1701,12 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha",
  "rand_core",
- "zerocopy",
 ]
 
 [[package]]
@@ -1854,7 +1853,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1893,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.25"
+version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
+checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "once_cell",
  "ring",
@@ -2051,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
@@ -2098,9 +2097,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2194,9 +2193,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2825,18 +2824,18 @@ checksum = "453f24cf9e21be2148954a438c72fb999da42b1d128105bfd73ce91e1c6c7d33"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.dependencies.brotli-decompressor]
-version = "4.0.1"
+version = "5.0.0"
 
 [workspace.dependencies.bytemuck]
 version = "1.19.0"

--- a/crates/jxl-bitstream/Cargo.toml
+++ b/crates/jxl-bitstream/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jpeg-xl", "decoder", "jxl-oxide"]
 categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/jxl-coding/Cargo.toml
+++ b/crates/jxl-coding/Cargo.toml
@@ -8,12 +8,12 @@ keywords = ["jpeg-xl", "decoder", "jxl-oxide"]
 categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 edition = "2024"
 
 [dependencies]
 tracing.workspace = true
 
 [dependencies.jxl-bitstream]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-bitstream"

--- a/crates/jxl-color/Cargo.toml
+++ b/crates/jxl-color/Cargo.toml
@@ -15,15 +15,15 @@ edition = "2024"
 tracing.workspace = true
 
 [dependencies.jxl-bitstream]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-bitstream"
 
 [dependencies.jxl-coding]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-coding"
 
 [dependencies.jxl-grid]
-version = "1.0.0-alpha.0"
+version = "0.6.0"
 path = "../jxl-grid"
 
 [dependencies.jxl-image]
@@ -31,9 +31,9 @@ version = "0.13.0"
 path = "../jxl-image"
 
 [dependencies.jxl-oxide-common]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-oxide-common"
 
 [dependencies.jxl-threadpool]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-threadpool"

--- a/crates/jxl-frame/Cargo.toml
+++ b/crates/jxl-frame/Cargo.toml
@@ -15,15 +15,15 @@ edition = "2024"
 tracing.workspace = true
 
 [dependencies.jxl-bitstream]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-bitstream"
 
 [dependencies.jxl-coding]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-coding"
 
 [dependencies.jxl-grid]
-version = "1.0.0-alpha.0"
+version = "0.6.0"
 path = "../jxl-grid"
 
 [dependencies.jxl-image]
@@ -35,11 +35,11 @@ version = "0.11.0"
 path = "../jxl-modular"
 
 [dependencies.jxl-oxide-common]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-oxide-common"
 
 [dependencies.jxl-threadpool]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-threadpool"
 
 [dependencies.jxl-vardct]

--- a/crates/jxl-grid/Cargo.toml
+++ b/crates/jxl-grid/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jpeg-xl", "decoder", "jxl-oxide"]
 categories = ["multimedia::images"]
 license = "MIT OR Apache-2.0"
 
-version = "1.0.0-alpha.0"
+version = "0.6.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/jxl-image/Cargo.toml
+++ b/crates/jxl-image/Cargo.toml
@@ -15,13 +15,13 @@ edition = "2024"
 tracing.workspace = true
 
 [dependencies.jxl-bitstream]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-bitstream"
 
 [dependencies.jxl-grid]
-version = "1.0.0-alpha.0"
+version = "0.6.0"
 path = "../jxl-grid"
 
 [dependencies.jxl-oxide-common]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-oxide-common"

--- a/crates/jxl-jbr/Cargo.toml
+++ b/crates/jxl-jbr/Cargo.toml
@@ -16,7 +16,7 @@ brotli-decompressor.workspace = true
 tracing.workspace = true
 
 [dependencies.jxl-bitstream]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-bitstream"
 
 [dependencies.jxl-frame]
@@ -24,7 +24,7 @@ version = "0.13.0"
 path = "../jxl-frame"
 
 [dependencies.jxl-grid]
-version = "1.0.0-alpha.0"
+version = "0.6.0"
 path = "../jxl-grid"
 
 [dependencies.jxl-image]
@@ -36,11 +36,11 @@ version = "0.11.0"
 path = "../jxl-modular"
 
 [dependencies.jxl-oxide-common]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-oxide-common"
 
 [dependencies.jxl-threadpool]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-threadpool"
 
 [dependencies.jxl-vardct]

--- a/crates/jxl-modular/Cargo.toml
+++ b/crates/jxl-modular/Cargo.toml
@@ -15,21 +15,21 @@ edition = "2024"
 tracing.workspace = true
 
 [dependencies.jxl-bitstream]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-bitstream"
 
 [dependencies.jxl-coding]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-coding"
 
 [dependencies.jxl-grid]
-version = "1.0.0-alpha.0"
+version = "0.6.0"
 path = "../jxl-grid"
 
 [dependencies.jxl-oxide-common]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-oxide-common"
 
 [dependencies.jxl-threadpool]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-threadpool"

--- a/crates/jxl-oxide-common/Cargo.toml
+++ b/crates/jxl-oxide-common/Cargo.toml
@@ -6,11 +6,11 @@ repository = "https://github.com/tirr-c/jxl-oxide.git"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 edition = "2024"
 
 [dependencies]
 
 [dependencies.jxl-bitstream]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-bitstream"

--- a/crates/jxl-oxide/Cargo.toml
+++ b/crates/jxl-oxide/Cargo.toml
@@ -25,7 +25,7 @@ default-features = false
 optional = true
 
 [dependencies.jxl-bitstream]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-bitstream"
 
 [dependencies.jxl-color]
@@ -37,7 +37,7 @@ version = "0.13.0"
 path = "../jxl-frame"
 
 [dependencies.jxl-grid]
-version = "1.0.0-alpha.0"
+version = "0.6.0"
 path = "../jxl-grid"
 
 [dependencies.jxl-image]
@@ -49,7 +49,7 @@ version = "0.2.0"
 path = "../jxl-jbr"
 
 [dependencies.jxl-oxide-common]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-oxide-common"
 
 [dependencies.jxl-render]
@@ -57,7 +57,7 @@ version = "0.12.0"
 path = "../jxl-render"
 
 [dependencies.jxl-threadpool]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-threadpool"
 
 [dependencies.lcms2]

--- a/crates/jxl-render/Cargo.toml
+++ b/crates/jxl-render/Cargo.toml
@@ -16,11 +16,11 @@ bytemuck.workspace = true
 tracing.workspace = true
 
 [dependencies.jxl-bitstream]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-bitstream"
 
 [dependencies.jxl-coding]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-coding"
 
 [dependencies.jxl-color]
@@ -32,7 +32,7 @@ version = "0.13.0"
 path = "../jxl-frame"
 
 [dependencies.jxl-grid]
-version = "1.0.0-alpha.0"
+version = "0.6.0"
 path = "../jxl-grid"
 
 [dependencies.jxl-image]
@@ -44,11 +44,11 @@ version = "0.11.0"
 path = "../jxl-modular"
 
 [dependencies.jxl-oxide-common]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-oxide-common"
 
 [dependencies.jxl-threadpool]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-threadpool"
 
 [dependencies.jxl-vardct]

--- a/crates/jxl-threadpool/Cargo.toml
+++ b/crates/jxl-threadpool/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 keywords = ["jxl-oxide"]
 license = "MIT OR Apache-2.0"
 
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/jxl-vardct/Cargo.toml
+++ b/crates/jxl-vardct/Cargo.toml
@@ -15,15 +15,15 @@ edition = "2024"
 tracing.workspace = true
 
 [dependencies.jxl-bitstream]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-bitstream"
 
 [dependencies.jxl-coding]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-coding"
 
 [dependencies.jxl-grid]
-version = "1.0.0-alpha.0"
+version = "0.6.0"
 path = "../jxl-grid"
 
 [dependencies.jxl-modular]
@@ -31,9 +31,9 @@ version = "0.11.0"
 path = "../jxl-modular"
 
 [dependencies.jxl-oxide-common]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-oxide-common"
 
 [dependencies.jxl-threadpool]
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 path = "../jxl-threadpool"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -86,14 +86,14 @@ dependencies = [
 
 [[package]]
 name = "jxl-bitstream"
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "jxl-coding"
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 dependencies = [
  "jxl-bitstream",
  "tracing",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "jxl-grid"
-version = "1.0.0-alpha.0"
+version = "0.6.0"
 dependencies = [
  "tracing",
 ]
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "jxl-oxide-common"
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 dependencies = [
  "jxl-bitstream",
 ]
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "jxl-threadpool"
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 dependencies = [
  "tracing",
 ]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -19,15 +19,21 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "1.3.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+
+[[package]]
+name = "bitflags"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -35,15 +41,15 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "cc"
-version = "1.1.31"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "jobserver",
  "libc",
@@ -51,11 +57,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.32"
+name = "cfg-if"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom",
  "libc",
 ]
 
@@ -81,6 +106,7 @@ dependencies = [
  "jxl-bitstream",
  "jxl-coding",
  "jxl-grid",
+ "jxl-image",
  "jxl-oxide-common",
  "jxl-threadpool",
  "tracing",
@@ -113,7 +139,6 @@ name = "jxl-image"
 version = "0.13.0"
 dependencies = [
  "jxl-bitstream",
- "jxl-color",
  "jxl-grid",
  "jxl-oxide-common",
  "tracing",
@@ -226,32 +251,37 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7"
+checksum = "cf78f52d400cf2d84a3a973a78a592b4adc535739e0a5597a0da6f0c357adc75"
 dependencies = [
  "arbitrary",
  "cc",
- "once_cell",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "shlex"
@@ -261,9 +291,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-core",
@@ -271,9 +301,27 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
 ]


### PR DESCRIPTION
Not stabilizing jxl-grid because I'm not very sure about its current API surface.