### PR TITLE
jxl-oxide: Add `JxlImageBuilder::force_wide_buffers()`

### DIFF
--- a/crates/jxl-oxide-cli/src/commands/decode.rs
+++ b/crates/jxl-oxide-cli/src/commands/decode.rs
@@ -79,6 +79,9 @@ pub struct DecodeArgs {
     /// External CMS will handle ICC profiles jxl-oxide cannot handle.
     #[arg(long)]
     pub cms: Option<Cms>,
+    /// (unstable) Force 32-bit Modular buffers when decoding.
+    #[arg(long)]
+    pub force_wide_buffers: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]

--- a/crates/jxl-oxide-cli/src/decode.rs
+++ b/crates/jxl-oxide-cli/src/decode.rs
@@ -10,7 +10,9 @@ pub fn handle_decode(args: DecodeArgs) -> Result<()> {
 
     let pool = crate::create_thread_pool(args.num_threads);
 
-    let mut image_builder = JxlImage::builder().pool(pool.clone());
+    let mut image_builder = JxlImage::builder()
+        .pool(pool.clone())
+        .force_wide_buffers(args.force_wide_buffers);
     if args.approx_memory_limit != 0 {
         let tracker = AllocTracker::with_limit(args.approx_memory_limit);
         image_builder = image_builder.alloc_tracker(tracker);


### PR DESCRIPTION
Might help debugging accidentally-non-comformant images.