### PR TITLE
Fix `image` crate integration failing to load image with reference frame

### DIFF
--- a/crates/jxl-oxide-tests/tests/image/mod.rs
+++ b/crates/jxl-oxide-tests/tests/image/mod.rs
@@ -86,3 +86,14 @@ fn icc_profile() {
         .unwrap();
     assert_eq!(&icc, include_bytes!("./grayscale.icc"));
 }
+
+#[test]
+fn with_reference_frame() {
+    let path = util::conformance_path("patches");
+    let file = File::open(path).unwrap();
+    let decoder = JxlDecoder::new(file).unwrap();
+
+    let image = DynamicImage::from_decoder(decoder).unwrap();
+    assert_eq!(image.width(), 1600);
+    assert_eq!(image.height(), 1096);
+}

--- a/crates/jxl-oxide/src/integration/image.rs
+++ b/crates/jxl-oxide/src/integration/image.rs
@@ -174,7 +174,7 @@ impl<R: Read> JxlDecoder<R> {
     }
 
     fn load_until_first_keyframe(&mut self) -> crate::Result<()> {
-        self.load_until_condition(|image| Ok(image.ctx.loaded_frames() > 0))?;
+        self.load_until_condition(|image| Ok(image.ctx.loaded_keyframes() > 0))?;
 
         if self.image.frame_by_keyframe(0).is_none() {
             return Err(std::io::Error::new(


### PR DESCRIPTION
Fixes #473