### PR TITLE
jxl-coding: Disable single token fast path if LZ77 is enabled

### DIFF
--- a/crates/jxl-coding/src/lib.rs
+++ b/crates/jxl-coding/src/lib.rs
@@ -153,6 +153,9 @@ impl Decoder {
     /// Returns the token to be decoded if the decoder always emits single token repeatedly.
     #[inline]
     pub fn single_token(&self, cluster: u8) -> Option<u32> {
+        if let Lz77::Enabled { .. } = self.lz77 {
+            return None;
+        }
         self.inner.single_token(cluster)
     }
 


### PR DESCRIPTION
Decoder cannot fill Modular buffers statelessly when LZ77 is enabled, because LZ77 is stateful (e.g. leftover LZ77 copies, decoded symbol window).