### PR TITLE
Add `image` crate decoding hook

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ features = ["std"]
 [profile.opt]
 inherits = "release"
 debug = 1
+
+[patch.crates-io]
+image = {git = "https://github.com/image-rs/image"}


### PR DESCRIPTION
The soon-to-be-released version of `image` crate allows registering decoding hooks for external image formats, so that format-agnostic functions such as `ImageReader::open("image.jxl")?.decode()?;` just work.

Tested with `wondermagick` and confirmed to work, at least for pixel data (I don't have any samples of JPEG XL images with Exif and ICC). You can see how it fits into a real-world project here: https://github.com/Shnatsel/wondermagick/pull/18

Marking it as draft until the relevant `image` version actually ships. The git dependency needs to be removed before merging.