### PR TITLE
Remove ImageDecoderRect implementation from `image` integration

### DIFF
--- a/crates/jxl-oxide/src/integration/image.rs
+++ b/crates/jxl-oxide/src/integration/image.rs
@@ -386,33 +386,6 @@ impl<R: Read> image::ImageDecoder for JxlDecoder<R> {
     }
 }
 
-impl<R: Read> image::ImageDecoderRect for JxlDecoder<R> {
-    fn read_rect(
-        &mut self,
-        x: u32,
-        y: u32,
-        width: u32,
-        height: u32,
-        buf: &mut [u8],
-        row_pitch: usize,
-    ) -> ImageResult<()> {
-        let crop = CropInfo {
-            width,
-            height,
-            left: x,
-            top: y,
-        };
-
-        self.read_image_inner(crop, buf, Some(row_pitch))
-            .map_err(|e| {
-                ImageError::Decoding(DecodingError::new(
-                    ImageFormatHint::PathExtension("jxl".into()),
-                    e,
-                ))
-            })
-    }
-}
-
 fn stream_to_buf<Sample: crate::FrameBufferSample>(
     mut stream: crate::ImageStream<'_>,
     buf: &mut [u8],


### PR DESCRIPTION
Upstream `image` will remove this trait in the next major release due to lack of both implementors and users: https://github.com/image-rs/image/pull/2681

I'm opening this PR now, ahead of the next `image` release, so that I could depend on `image` from git in my project and still be able to decode JPEG XL files.