### PR TITLE
Revert "Remove ImageDecoderRect implementation from `image` integration"

### DIFF
--- a/crates/jxl-oxide/src/integration/image.rs
+++ b/crates/jxl-oxide/src/integration/image.rs
@@ -386,6 +386,33 @@ impl<R: Read> image::ImageDecoder for JxlDecoder<R> {
     }
 }
 
+impl<R: Read> image::ImageDecoderRect for JxlDecoder<R> {
+    fn read_rect(
+        &mut self,
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+        buf: &mut [u8],
+        row_pitch: usize,
+    ) -> ImageResult<()> {
+        let crop = CropInfo {
+            width,
+            height,
+            left: x,
+            top: y,
+        };
+
+        self.read_image_inner(crop, buf, Some(row_pitch))
+            .map_err(|e| {
+                ImageError::Decoding(DecodingError::new(
+                    ImageFormatHint::PathExtension("jxl".into()),
+                    e,
+                ))
+            })
+    }
+}
+
 fn stream_to_buf<Sample: crate::FrameBufferSample>(
     mut stream: crate::ImageStream<'_>,
     buf: &mut [u8],


### PR DESCRIPTION
Reverts tirr-c/jxl-oxide#488

`image` made further changes to the decoder interface for their upcoming release (likely v1.0) so the current code is not usable for the upcoming release as-is. And if we're sticking to `image` 0.25.x there's no point in removing this method.