### PR TITLE
Allow subsampled image for LF smoothing

### DIFF
--- a/crates/jxl-render/src/vardct/aarch64/mod.rs
+++ b/crates/jxl-render/src/vardct/aarch64/mod.rs
@@ -1,6 +1,7 @@
 use std::arch::is_aarch64_feature_detected;
 
 use jxl_grid::AllocTracker;
+use jxl_modular::ChannelShift;
 
 use super::generic;
 
@@ -11,6 +12,7 @@ pub use transform::transform_varblocks;
 pub fn adaptive_lf_smoothing_impl(
     width: usize,
     height: usize,
+    shifts: [ChannelShift; 3],
     lf_image: [&mut [f32]; 3],
     lf_scale: [f32; 3],
     tracker: Option<&AllocTracker>,
@@ -18,20 +20,21 @@ pub fn adaptive_lf_smoothing_impl(
     if is_aarch64_feature_detected!("neon") {
         // SAFETY: Feature set is checked above.
         return unsafe {
-            adaptive_lf_smoothing_core_neon(width, height, lf_image, lf_scale, tracker)
+            adaptive_lf_smoothing_core_neon(width, height, shifts, lf_image, lf_scale, tracker)
         };
     }
 
-    generic::adaptive_lf_smoothing_impl(width, height, lf_image, lf_scale, tracker)
+    generic::adaptive_lf_smoothing_impl(width, height, shifts, lf_image, lf_scale, tracker)
 }
 
 #[target_feature(enable = "neon")]
 unsafe fn adaptive_lf_smoothing_core_neon(
     width: usize,
     height: usize,
+    shifts: [ChannelShift; 3],
     lf_image: [&mut [f32]; 3],
     lf_scale: [f32; 3],
     tracker: Option<&AllocTracker>,
 ) -> crate::Result<()> {
-    generic::adaptive_lf_smoothing_impl(width, height, lf_image, lf_scale, tracker)
+    generic::adaptive_lf_smoothing_impl(width, height, shifts, lf_image, lf_scale, tracker)
 }

--- a/crates/jxl-render/src/vardct/generic/mod.rs
+++ b/crates/jxl-render/src/vardct/generic/mod.rs
@@ -1,4 +1,5 @@
 use jxl_grid::{AlignedGrid, AllocTracker};
+use jxl_modular::ChannelShift;
 
 mod dct;
 mod transform;
@@ -7,21 +8,33 @@ pub use dct::dct_2d;
 #[allow(unused)]
 pub use transform::*;
 
+const SCALE_SELF: f32 = 0.052262735;
+const SCALE_SIDE: f32 = 0.2034514;
+const SCALE_DIAG: f32 = 0.03348292;
+
 #[inline(always)]
 pub fn adaptive_lf_smoothing_impl(
     width: usize,
     height: usize,
+    shifts: [ChannelShift; 3],
     [in_x, in_y, in_b]: [&mut [f32]; 3],
     [lf_x, lf_y, lf_b]: [f32; 3],
     tracker: Option<&AllocTracker>,
 ) -> crate::Result<()> {
-    const SCALE_SELF: f32 = 0.052262735;
-    const SCALE_SIDE: f32 = 0.2034514;
-    const SCALE_DIAG: f32 = 0.03348292;
-
     if width <= 2 || height <= 2 {
         // Nothing to do
         return Ok(());
+    }
+
+    if shifts.map(|x| x.hshift() + x.vshift()) != [0; 3] {
+        return adaptive_lf_smoothing_subsampled_impl(
+            width,
+            height,
+            shifts,
+            [in_x, in_y, in_b],
+            [lf_x, lf_y, lf_b],
+            tracker,
+        );
     }
 
     assert_eq!(in_x.len(), in_y.len());
@@ -93,6 +106,125 @@ pub fn adaptive_lf_smoothing_impl(
             in_x_prev = x_self;
             in_y_prev = y_self;
             in_b_prev = b_self;
+        }
+    }
+
+    Ok(())
+}
+
+fn adaptive_lf_smoothing_subsampled_impl(
+    width: usize,
+    height: usize,
+    shifts: [ChannelShift; 3],
+    in_xyb: [&mut [f32]; 3],
+    [lf_x, lf_y, lf_b]: [f32; 3],
+    tracker: Option<&AllocTracker>,
+) -> crate::Result<()> {
+    let dims = shifts.map(|shift| {
+        let (w, h) = shift.shift_size((width as u32, height as u32));
+        (w as usize, h as usize)
+    });
+    for (w, h) in dims {
+        if w <= 2 || h <= 2 {
+            return Ok(());
+        }
+    }
+
+    for ((w, h), in_lf) in std::iter::zip(dims, &in_xyb) {
+        assert_eq!(in_lf.len(), w * h);
+    }
+
+    let [in_x, in_y, in_b] = in_xyb;
+
+    let mut wa_x = AlignedGrid::with_alloc_tracker(dims[0].0 - 2, dims[0].1 - 2, tracker)?;
+    let mut wa_y = AlignedGrid::with_alloc_tracker(dims[1].0 - 2, dims[1].1 - 2, tracker)?;
+    let mut wa_b = AlignedGrid::with_alloc_tracker(dims[2].0 - 2, dims[2].1 - 2, tracker)?;
+
+    for (width, g, out) in [
+        (dims[0].0, &mut *in_x, wa_x.buf_mut()),
+        (dims[1].0, &mut *in_y, wa_y.buf_mut()),
+        (dims[2].0, &mut *in_b, wa_b.buf_mut()),
+    ] {
+        let up = g.chunks_exact(width);
+        let center = g[width..].chunks_exact(width);
+        let down = g[width * 2..].chunks_exact(width);
+        let out = out.chunks_exact_mut(width - 2);
+        for (((up, center), down), out) in up.zip(center).zip(down).zip(out) {
+            for (((u, c), d), out) in up
+                .windows(3)
+                .zip(center.windows(3))
+                .zip(down.windows(3))
+                .zip(out)
+            {
+                let me = c[1];
+                let side = u[1] + c[0] + c[2] + d[1];
+                let diag = u[0] + u[2] + d[0] + d[2];
+                *out = me * SCALE_SELF + side * SCALE_SIDE + diag * SCALE_DIAG;
+            }
+        }
+    }
+
+    let mut last_coords_y = [0; 3];
+    let mut current_row_x = vec![0.0; dims[0].0];
+    let mut current_row_y = vec![0.0; dims[1].0];
+    let mut current_row_b = vec![0.0; dims[2].0];
+    for row in 0..height {
+        let coords_y = shifts.map(|shift| row >> shift.vshift());
+        if std::iter::zip(coords_y, dims).any(|(row, (_, height))| row == 0 || row == height - 1) {
+            continue;
+        }
+
+        let row_x = &mut in_x[coords_y[0] * dims[0].0..][..dims[0].0];
+        let row_y = &mut in_y[coords_y[1] * dims[1].0..][..dims[1].0];
+        let row_b = &mut in_b[coords_y[2] * dims[2].0..][..dims[2].0];
+
+        if last_coords_y[0] != coords_y[0] {
+            current_row_x.copy_from_slice(row_x);
+        }
+        if last_coords_y[1] != coords_y[1] {
+            current_row_y.copy_from_slice(row_y);
+        }
+        if last_coords_y[2] != coords_y[2] {
+            current_row_b.copy_from_slice(row_b);
+        }
+        last_coords_y = coords_y;
+
+        for col in 0..width {
+            let coords_x = shifts.map(|shift| col >> shift.hshift());
+            if std::iter::zip(coords_x, dims).any(|(col, (width, _))| col == 0 || col == width - 1)
+            {
+                continue;
+            }
+
+            let skip_update: [_; 3] = std::array::from_fn(|idx| {
+                let shift = shifts[idx];
+                (coords_y[idx] << shift.vshift()) != row || (coords_x[idx] << shift.hshift()) != col
+            });
+
+            let x_self = current_row_x[coords_x[0]];
+            let x_wa = wa_x.get(coords_x[0] - 1, coords_y[0] - 1);
+            let x_gap_t = (x_wa - x_self).abs() / lf_x;
+
+            let y_self = current_row_y[coords_x[1]];
+            let y_wa = wa_y.get(coords_x[1] - 1, coords_y[1] - 1);
+            let y_gap_t = (y_wa - y_self).abs() / lf_y;
+
+            let b_self = current_row_b[coords_x[2]];
+            let b_wa = wa_b.get(coords_x[2] - 1, coords_y[2] - 1);
+            let b_gap_t = (b_wa - b_self).abs() / lf_b;
+
+            let gap = 0.5f32.max(x_gap_t).max(y_gap_t).max(b_gap_t);
+            let gap_scale = (3.0 - 4.0 * gap).max(0.0);
+
+            if !skip_update[0] {
+                row_x[coords_x[0]] = (x_wa - x_self) * gap_scale + x_self;
+            }
+            if !skip_update[1] {
+                row_y[coords_x[1]] = (y_wa - y_self) * gap_scale + y_self;
+            }
+            if !skip_update[2] {
+                row_b[coords_x[2]] = (b_wa - b_self) * gap_scale + b_self;
+            }
         }
     }
 

--- a/crates/jxl-render/src/vardct/mod.rs
+++ b/crates/jxl-render/src/vardct/mod.rs
@@ -61,6 +61,9 @@ pub(crate) fn render_vardct<S: Sample>(
 
     let jpeg_upsampling = frame_header.jpeg_upsampling;
     let subsampled = jpeg_upsampling.into_iter().any(|x| x != 0);
+    let shifts_cbycr: [_; 3] = std::array::from_fn(|idx| {
+        ChannelShift::from_jpeg_upsampling(frame_header.jpeg_upsampling, idx)
+    });
 
     let lf_global = match &cache.lf_global {
         Some(x) if !x.gmodular.is_partial() => x,
@@ -193,6 +196,7 @@ pub(crate) fn render_vardct<S: Sample>(
             if !frame_header.flags.skip_adaptive_lf_smoothing() {
                 tracing::trace_span!("Adaptive LF smoothing").in_scope(|| {
                     adaptive_lf_smoothing(
+                        shifts_cbycr,
                         lf_xyb.as_color_floats_mut(),
                         &lf_global.lf_dequant,
                         &lf_global_vardct.quantizer,
@@ -204,9 +208,6 @@ pub(crate) fn render_vardct<S: Sample>(
         };
 
         let fb = {
-            let shifts_cbycr: [_; 3] = std::array::from_fn(|idx| {
-                ChannelShift::from_jpeg_upsampling(frame_header.jpeg_upsampling, idx)
-            });
             let Region { width, height, .. } = modular_region;
 
             let mut fb = ImageWithRegion::new(3, tracker);
@@ -412,6 +413,7 @@ pub fn copy_lf_dequant<S: Sample>(
 }
 
 pub fn adaptive_lf_smoothing(
+    shifts: [ChannelShift; 3],
     lf_image: [&mut AlignedGrid<f32>; 3],
     lf_dequant: &LfChannelDequantization,
     quantizer: &Quantizer,
@@ -423,8 +425,8 @@ pub fn adaptive_lf_smoothing(
 
     let [in_x, in_y, in_b] = lf_image;
     let tracker = in_x.tracker();
-    let width = in_x.width();
-    let height = in_x.height();
+    let width = in_x.width().max(in_y.width()).max(in_b.width());
+    let height = in_x.height().max(in_y.height()).max(in_b.height());
 
     let in_x = in_x.buf_mut();
     let in_y = in_y.buf_mut();
@@ -433,6 +435,7 @@ pub fn adaptive_lf_smoothing(
     impls::adaptive_lf_smoothing_impl(
         width,
         height,
+        shifts,
         [in_x, in_y, in_b],
         [lf_x, lf_y, lf_b],
         tracker.as_ref(),

--- a/crates/jxl-render/src/vardct/wasm32/mod.rs
+++ b/crates/jxl-render/src/vardct/wasm32/mod.rs
@@ -1,4 +1,5 @@
 use jxl_grid::AllocTracker;
+use jxl_modular::ChannelShift;
 
 use super::generic;
 
@@ -9,9 +10,10 @@ pub use transform::transform_varblocks;
 pub fn adaptive_lf_smoothing_impl(
     width: usize,
     height: usize,
+    shifts: [ChannelShift; 3],
     lf_image: [&mut [f32]; 3],
     lf_scale: [f32; 3],
     tracker: Option<&AllocTracker>,
 ) -> crate::Result<()> {
-    generic::adaptive_lf_smoothing_impl(width, height, lf_image, lf_scale, tracker)
+    generic::adaptive_lf_smoothing_impl(width, height, shifts, lf_image, lf_scale, tracker)
 }

--- a/crates/jxl-render/src/vardct/x86_64/mod.rs
+++ b/crates/jxl-render/src/vardct/x86_64/mod.rs
@@ -1,4 +1,5 @@
 use jxl_grid::AllocTracker;
+use jxl_modular::ChannelShift;
 
 use super::generic;
 
@@ -9,6 +10,7 @@ pub use transform::transform_varblocks;
 pub fn adaptive_lf_smoothing_impl(
     width: usize,
     height: usize,
+    shifts: [ChannelShift; 3],
     lf_image: [&mut [f32]; 3],
     lf_scale: [f32; 3],
     tracker: Option<&AllocTracker>,
@@ -16,11 +18,11 @@ pub fn adaptive_lf_smoothing_impl(
     if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma") {
         // SAFETY: Feature set is checked above.
         return unsafe {
-            adaptive_lf_smoothing_core_avx2(width, height, lf_image, lf_scale, tracker)
+            adaptive_lf_smoothing_core_avx2(width, height, shifts, lf_image, lf_scale, tracker)
         };
     }
 
-    generic::adaptive_lf_smoothing_impl(width, height, lf_image, lf_scale, tracker)
+    generic::adaptive_lf_smoothing_impl(width, height, shifts, lf_image, lf_scale, tracker)
 }
 
 #[target_feature(enable = "avx2")]
@@ -28,9 +30,10 @@ pub fn adaptive_lf_smoothing_impl(
 unsafe fn adaptive_lf_smoothing_core_avx2(
     width: usize,
     height: usize,
+    shifts: [ChannelShift; 3],
     lf_image: [&mut [f32]; 3],
     lf_scale: [f32; 3],
     tracker: Option<&AllocTracker>,
 ) -> crate::Result<()> {
-    generic::adaptive_lf_smoothing_impl(width, height, lf_image, lf_scale, tracker)
+    generic::adaptive_lf_smoothing_impl(width, height, shifts, lf_image, lf_scale, tracker)
 }


### PR DESCRIPTION
Adaptive LF smoothing process for subsampled image is not defined by the spec (yet). jxl-oxide does the following:

1. For each channel in downsampled LF image, compute 3x3 weighted sum `wa_{x,y,b}` as defined in the spec.
2. For each *upsampled LF image coordinate*:
   1. Find the corresponding `self_{x,y,b}` (original LF image sample) and `wa_{x,y,b}`, and compute smoothed samples as usual.
      - If there is *any* channel that has no corresponding `wa` (this happens at the edge of the frame), skip smoothing for this coordinate.
   2. For each downsampled channel, if the coordinate is aligned for the channel, use the smoothed sample as the result of adaptive LF smoothing.