### PR TITLE
wasm: allow getting image data from render

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,6 +1246,7 @@ dependencies = [
 name = "jxl-oxide-wasm"
 version = "0.12.6"
 dependencies = [
+ "bytemuck",
  "console_error_panic_hook",
  "console_log",
  "jxl-oxide",

--- a/crates/jxl-oxide-wasm/Cargo.toml
+++ b/crates/jxl-oxide-wasm/Cargo.toml
@@ -20,6 +20,9 @@ miniz_oxide = "0.8.7"
 png = "0.18.0"
 wasm-bindgen = "0.2.93"
 
+[dependencies.bytemuck]
+workspace = true
+
 [dependencies.console_error_panic_hook]
 version = "0.1.7"
 optional = true
@@ -31,6 +34,7 @@ optional = true
 [dependencies.jxl-oxide]
 version = "0.12.6"
 path = "../jxl-oxide"
+version = "0.12.6"
 default-features = false
 
 [dependencies.web-sys]

--- a/crates/jxl-oxide-wasm/src/lib.rs
+++ b/crates/jxl-oxide-wasm/src/lib.rs
@@ -1,3 +1,4 @@
+use bytemuck::cast_slice_mut;
 use jxl_oxide::{
     EnumColourEncoding, InitializeResult, JxlImage, PixelFormat, Render, RenderingIntent,
     UninitializedJxlImage, color::ColourEncoding,
@@ -371,14 +372,18 @@ impl RenderResult {
     #[wasm_bindgen(js_name = imageData)]
     pub fn image_data(&self) -> Vec<u8> {
         let mut stream = self.image.stream();
-        let bytes_per_channel = if self.need_high_precision { 2 } else { 1 };
-        let mut buf = vec![
-            0u8;
-            (stream.width() * stream.height() * stream.channels() * bytes_per_channel)
-                as usize
-        ];
-        stream.write_to_buffer(&mut buf);
-        buf
+        if self.need_high_precision {
+            let mut buf =
+                vec![0u8; (stream.width() * stream.height() * stream.channels()) as usize * 2];
+            let ar_slice: &mut [[u8; 2]] = cast_slice_mut(buf.as_mut_slice());
+            stream.write_to_buffer(ar_slice);
+            buf
+        } else {
+            let mut buf =
+                vec![0u8; (stream.width() * stream.height() * stream.channels()) as usize];
+            stream.write_to_buffer(&mut buf);
+            buf
+        }
     }
 }
 

--- a/crates/jxl-oxide-wasm/src/lib.rs
+++ b/crates/jxl-oxide-wasm/src/lib.rs
@@ -356,6 +356,38 @@ impl RenderResult {
         writer.finish().map_err(|e| e.to_string())?;
         Ok(out)
     }
+
+    #[wasm_bindgen(js_name = imageDimensions)]
+    pub fn image_dimensions(&self) -> ImageDimensions {
+        let stream = self.image.stream();
+        ImageDimensions {
+            width: stream.width(),
+            height: stream.height(),
+            channels: stream.channels(),
+            depth: if self.need_high_precision { 16 } else { 8 },
+        }
+    }
+
+    #[wasm_bindgen(js_name = imageData)]
+    pub fn image_data(&self) -> Vec<u8> {
+        let mut stream = self.image.stream();
+        let bytes_per_channel = if self.need_high_precision { 2 } else { 1 };
+        let mut buf = vec![
+            0u8;
+            (stream.width() * stream.height() * stream.channels() * bytes_per_channel)
+                as usize
+        ];
+        stream.write_to_buffer(&mut buf);
+        buf
+    }
+}
+
+#[wasm_bindgen]
+pub struct ImageDimensions {
+    pub width: u32,
+    pub height: u32,
+    pub channels: u32,
+    pub depth: u32,
 }
 
 #[wasm_bindgen(inspectable)]

--- a/crates/jxl-oxide/src/fb.rs
+++ b/crates/jxl-oxide/src/fb.rs
@@ -459,6 +459,9 @@ impl FrameBufferSample for f32 {}
 /// Output as 16-bit unsigned integer samples.
 impl FrameBufferSample for u16 {}
 
+/// Output as 16-bit unsigned integer samples, stored as 2 bytes.
+impl FrameBufferSample for [u8; 2] {}
+
 /// Output as 8-bit unsigned integer samples.
 impl FrameBufferSample for u8 {}
 
@@ -532,6 +535,22 @@ mod private {
         #[inline]
         fn copy_from_f32(&mut self, val: f32) {
             *self = (val * 65535.0 + 0.5).clamp(0.0, 65535.0) as u16;
+        }
+    }
+
+    impl Sealed for [u8; 2] {
+        #[inline]
+        fn copy_from_grid(&mut self, grid: &ImageBuffer, x: usize, y: usize, bit_depth: BitDepth) {
+            let mut val16 = 0u16;
+            val16.copy_from_grid(grid, x, y, bit_depth);
+            *self = val16.to_ne_bytes();
+        }
+
+        #[inline]
+        fn copy_from_f32(&mut self, val: f32) {
+            let mut val16 = 0u16;
+            val16.copy_from_f32(val);
+            *self = val16.to_ne_bytes();
         }
     }
 


### PR DESCRIPTION
I've a project where I need to access the raw pixel data from a jxl image, currently this requires re-encoding the image as png, only to then immediately decode it again.

With this change one can directly export the jxl image to raw pixel data.

Additionally, `FrameBufferSample` has been implemented for `[u8; 2]` to allow writing 16 bit image data to a `Vec<u8>` (trough some `bytemuck` casting) without intermediate buffer copying.